### PR TITLE
Move to unblocking try_send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Version 0.1.1
+
+- Move public API to use the unblocking try_send() to replace send().
+- Add `Again` in Error type to support retry.
+
+# Version 0.1.0
+
+- Initial version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Version 0.1.1
+# Version 0.2.0
 
-- Move public API to use the unblocking try_send() to replace send().
+- Public API internally to use the unblocking try_send() to replace send().
 - Add `Again` in Error type to support retry.
 
 # Version 0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdns-sd"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["keepsimple <keepsimple@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdns-sd"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["keepsimple <keepsimple@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -755,6 +755,7 @@ impl Zeroconf {
 
     /// Returns false if failed to receive a packet,
     /// otherwise returns true.
+    /// `sockfd` is expected to be connectionless (i.e. UDP socket).
     fn handle_read(&mut self, sockfd: RawFd) -> bool {
         let mut buf = vec![0; MAX_MSG_ABSOLUTE];
         let (sz, src_addr) = match recvfrom(sockfd, &mut buf) {

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1,9 +1,10 @@
-use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo, UnregisterStatus};
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-use std::thread::sleep;
-use std::time::Duration;
-use std::time::SystemTime;
+use mdns_sd::{Error, ServiceDaemon, ServiceEvent, ServiceInfo, UnregisterStatus};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    thread::sleep,
+    time::{Duration, SystemTime},
+};
 
 /// This test covers:
 /// register(announce), browse(query), response, unregister, shutdown.
@@ -94,6 +95,16 @@ fn integration_success() {
         }
     });
 
+    // Try to flood the browsing until we got Error::Again.
+    loop {
+        match d.browse(ty_domain) {
+            Ok(_chan) => {}
+            Err(Error::Again) => break,
+            Err(_e) => assert!(false), // Should not happen.
+        }
+    }
+
+    // Wait a bit to let the daemon process commands in the channel.
     sleep(Duration::from_secs(1));
 
     // Unregister the service


### PR DESCRIPTION
Currently the public API uses `send()` to send commands to the daemon, which is a blocking call even though it rarely blocks. To make sure it works well in async environments, we are moving to `try_send` that is unblocking.

A new error value `Again` is added to allow the detection of channel full so that the caller can retry if needed.