### PR TITLE
allow non_block as option in new_socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.2.1
+
+- mDNS daemon respond socket to be blocking for simpler send.
+
 # Version 0.2.0
 
 - Public API internally to use the unblocking try_send() to replace send().

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdns-sd"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["keepsimple <keepsimple@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
Since v0.2.0, the listening socket is set to be `NON_BLOCK`, however the respond_socket does not need to be NON_BLOCK, as handling EAGAIN is complicated for the send. In my testing, the application often gets `EAGAIN` from the send path.

This patch is to make `NON_BLOCK` an option so that the listening socket and the respond sockets can be set differently.