### PR TITLE
fix cache refresh and add metrics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,7 @@ pub enum UnregisterStatus {
 
 /// Different counter types included in the metrics.
 #[derive(Hash, Eq, PartialEq, Clone)]
-pub enum Counter {
+enum Counter {
     Register,
     Unregister,
     Announce,
@@ -238,7 +238,20 @@ pub enum Counter {
     PacketResend,
 }
 
-pub type Metrics = HashMap<Counter, i64>;
+impl fmt::Display for Counter {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Counter::Register => write!(f, "register"),
+            Counter::Unregister => write!(f, "unregister"),
+            Counter::Announce => write!(f, "re-boardcast"),
+            Counter::SendQuery => write!(f, "send-query"),
+            Counter::SendResponse => write!(f, "respond-query"),
+            Counter::PacketResend => write!(f, "resend-packet"),
+        }
+    }
+}
+
+pub type Metrics = HashMap<String, i64>;
 
 /// A daemon thread for mDNS
 ///
@@ -1182,10 +1195,11 @@ impl Zeroconf {
 
     /// Increases the value of `counter` by `count`.
     fn increase_counter(&mut self, counter: Counter, count: i64) {
-        match self.counters.get_mut(&counter) {
+        let key = counter.to_string();
+        match self.counters.get_mut(&key) {
             Some(v) => *v += count,
             None => {
-                self.counters.insert(counter, count);
+                self.counters.insert(key, count);
             }
         }
     }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -125,6 +125,16 @@ fn integration_success() {
 
     sleep(Duration::from_secs(1));
 
+    // Verify metrics.
+    let metrics_receiver = d.get_metrics().unwrap();
+    let metrics = metrics_receiver.recv().unwrap();
+    assert_eq!(metrics["register"], 1);
+    assert_eq!(metrics["unregister"], 1);
+    assert_eq!(metrics["register-resend"], 1);
+    assert_eq!(metrics["unregister-resend"], 1);
+    assert!(metrics["browse"] >= 2); // browse has been retransmitted.
+    assert!(metrics["respond"] >= 2); // respond has been sent for every browse.
+
     // Shutdown
     d.shutdown().unwrap();
 }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -128,6 +128,7 @@ fn integration_success() {
     // Verify metrics.
     let metrics_receiver = d.get_metrics().unwrap();
     let metrics = metrics_receiver.recv().unwrap();
+    println!("metrics: {:?}", &metrics);
     assert_eq!(metrics["register"], 1);
     assert_eq!(metrics["unregister"], 1);
     assert_eq!(metrics["register-resend"], 1);


### PR DESCRIPTION
1. The main purpose is to fix a bug in "cache refresh":  the daemon would repeatedly send out query packets to refresh its cache when a record `refresh_due` returns True before the record expires.

Because there is a "20% of TTL" time span between "refresh" and "expire", this can cause an outgoing packets surge due to cache refresh.  The fix is:  only refresh once for any refresh-due record. 

2. To debug this issue and to help similar debugging in the future, I also added a metrics (counters) for outgoing traffic. A user can easily pull the metrics by calling `get_metrics` of the daemon, and use `recv()` or `try_recv()`. 

3. Fix a problem in `retransmission`:  currently the retransmissions is a `BTreeMap` and there is a non-zero chance that two retransmissions are scheduled with the same `next_time`, hence the 2nd one will overwrite the first one in the BTreeMap due to the same key.  The fix is to change the data structure to a `Vec`.

4. Updated the integration test to cover the metrics.