### PR TITLE
Use flume instead of crossbeam-channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.46.0
+          toolchain: 1.49.0
           override: true
           components: rustfmt, clippy
       - name: Run rustfmt and fail if any warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,11 @@ keywords = ["mdns", "discovery", "service-discovery", "zeroconf", "dns-sd"]
 categories = ["network-programming"]
 description = "mDNS Service Discovery library with no async runtime dependency"
 
+[features]
+async = ["flume/async"]
+default = ["async"]
+
 [dependencies]
-crossbeam-channel = "0.5.1" # channel between threads
+flume = { version = "0.10", default-features = false } # channel between threads
 log = "0.4.14"              # logging
 nix = "0.23.0"              # socket APIs

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ This is a small implementation of mDNS (Multicast DNS) based service discovery i
 
 ## Approach
 
-We are not using async/.await, instead we create a new thread to run a mDNS daemon. The API interacts with the daemon via [`crossbeam-channel`](https://crates.io/crates/crossbeam-channel). Because the channel handles are `Clone` and `Send`, they work easily with both sync and async code. For more details, please see the [documentation](https://docs.rs/mdns-sd).
+We are not using async/.await, instead we create a new thread to run a mDNS daemon.
+
+The API interacts with the daemon via [`flume`](https://crates.io/crates/flume). Because the channel handles are `Clone` and `Send`, they work easily with both sync and async code. For more details, please see the [documentation](https://docs.rs/mdns-sd).
 
 ## Compatibility and Limitations
 
@@ -29,7 +31,7 @@ Currently this library has the following limitations:
 
 ## Minimum Rust version
 
-Tested against Rust 1.46.0
+Tested against Rust 1.49.0
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@
 // In mDNS and DNS, the basic data structure is "Resource Record" (RR), where
 // in Service Discovery, the basic data structure is "Service Info". One Service Info
 // corresponds to a set of DNS Resource Records.
-use flume::{bounded, Receiver, Sender, TrySendError};
+use flume::{bounded, Sender, TrySendError};
 use log::{debug, error};
 use nix::{
     errno, fcntl,
@@ -177,6 +177,9 @@ impl fmt::Display for Error {
 
 /// One and only `Result` type from this library crate.
 pub type Result<T> = core::result::Result<T, Error>;
+
+/// Re-export the channel Receiver
+pub use flume::Receiver;
 
 /// A simple macro to report all kinds of errors.
 macro_rules! e_fmt {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This library creates one new thread to run a mDNS daemon, and exposes
 //! its API that interacts with the daemon via a
-//! [`crossbeam-channel`](https://crates.io/crates/crossbeam-channel).
+//! [`flume`](https://crates.io/crates/flume).
 //!
 //! For example, a client querying (browsing) a service behaves like this:
 //!```text
@@ -131,7 +131,7 @@
 // In mDNS and DNS, the basic data structure is "Resource Record" (RR), where
 // in Service Discovery, the basic data structure is "Service Info". One Service Info
 // corresponds to a set of DNS Resource Records.
-use crossbeam_channel::{bounded, Receiver, Sender, TrySendError};
+use flume::{bounded, Receiver, Sender, TrySendError};
 use log::{debug, error};
 use nix::{
     errno, fcntl,
@@ -297,7 +297,7 @@ impl ServiceDaemon {
             .try_send(Command::Browse(service_type.to_string(), 1, resp_s))
             .map_err(|e| match e {
                 TrySendError::Full(_) => Error::Again,
-                e => e_fmt!("crossbeam::channel::send failed: {}", e),
+                e => e_fmt!("flume::channel::send failed: {}", e),
             })?;
         Ok(resp_r)
     }
@@ -311,7 +311,7 @@ impl ServiceDaemon {
             .try_send(Command::StopBrowse(ty_domain.to_string()))
             .map_err(|e| match e {
                 TrySendError::Full(_) => Error::Again,
-                e => e_fmt!("crossbeam::channel::send failed: {}", e),
+                e => e_fmt!("flume::channel::send failed: {}", e),
             })?;
         Ok(())
     }
@@ -322,7 +322,7 @@ impl ServiceDaemon {
             .try_send(Command::Register(service_info))
             .map_err(|e| match e {
                 TrySendError::Full(_) => Error::Again,
-                e => e_fmt!("crossbeam::channel::send failed: {}", e),
+                e => e_fmt!("flume::channel::send failed: {}", e),
             })?;
         Ok(())
     }
@@ -340,7 +340,7 @@ impl ServiceDaemon {
             .try_send(Command::Unregister(fullname.to_lowercase(), resp_s))
             .map_err(|e| match e {
                 TrySendError::Full(_) => Error::Again,
-                e => e_fmt!("crossbeam::channel::send failed: {}", e),
+                e => e_fmt!("flume::channel::send failed: {}", e),
             })?;
         Ok(resp_r)
     }
@@ -352,7 +352,7 @@ impl ServiceDaemon {
     pub fn shutdown(&self) -> Result<()> {
         self.sender.try_send(Command::Exit).map_err(|e| match e {
             TrySendError::Full(_) => Error::Again,
-            e => e_fmt!("crossbeam::channel::send failed: {}", e),
+            e => e_fmt!("flume::channel::send failed: {}", e),
         })
     }
 
@@ -366,7 +366,7 @@ impl ServiceDaemon {
             .try_send(Command::GetMetrics(resp_s))
             .map_err(|e| match e {
                 TrySendError::Full(_) => Error::Again,
-                e => e_fmt!("crossbeam::channel::try_send failed: {}", e),
+                e => e_fmt!("flume::channel::try_send failed: {}", e),
             })?;
         Ok(resp_r)
     }


### PR DESCRIPTION
Makes even easier to use the library from an async context.