### PR TITLE
add support on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ default = ["async"]
 [dependencies]
 flume = { version = "0.10", default-features = false }     # channel between threads
 log = "0.4.14"                                             # logging
-socket2 = { version = "0.4", features = ["all"] }          # socket APIs
 polling = "2.1.0"                                          # select/poll sockets
+socket2 = { version = "0.4", features = ["all"] }          # socket APIs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ async = ["flume/async"]
 default = ["async"]
 
 [dependencies]
-flume = { version = "0.10", default-features = false } # channel between threads
-log = "0.4.14"                                         # logging
-nix = "0.24.1"                                         # socket APIs
+flume = { version = "0.10", default-features = false }     # channel between threads
+log = "0.4.14"                                             # logging
+socket2 = { version = "0.3.19", features = ["reuseport"] } # socket APIs
+polling = "2.1.0"                                          # select/poll sockets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ default = ["async"]
 [dependencies]
 flume = { version = "0.10", default-features = false }     # channel between threads
 log = "0.4.14"                                             # logging
-socket2 = { version = "0.4.4", features = ["all"] }        # socket APIs
+socket2 = { version = "0.4", features = ["all"] }          # socket APIs
 polling = "2.1.0"                                          # select/poll sockets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ default = ["async"]
 [dependencies]
 flume = { version = "0.10", default-features = false }     # channel between threads
 log = "0.4.14"                                             # logging
-socket2 = "0.4.4"                                          # socket APIs
+socket2 = { version = "0.4.4", features = ["all"] }        # socket APIs
 polling = "2.1.0"                                          # select/poll sockets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ default = ["async"]
 [dependencies]
 flume = { version = "0.10", default-features = false }     # channel between threads
 log = "0.4.14"                                             # logging
-socket2 = { version = "0.3.19", features = ["reuseport"] } # socket APIs
+socket2 = "0.4.4"                                          # socket APIs
 polling = "2.1.0"                                          # select/poll sockets

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -547,11 +547,13 @@ impl ServiceDaemon {
                 None => error!("StopBrowse: cannot find querier for {}", &ty_domain),
                 Some((ty, sender)) => {
                     // Remove pending browse commands in the reruns.
+                    debug!("StopBrowse: removed queryer for {}", &ty);
                     let mut i = 0;
                     while i < zc.retransmissions.len() {
                         if let Command::Browse(t, _, _) = &zc.retransmissions[i].command {
                             if t == &ty {
                                 zc.retransmissions.remove(i);
+                                debug!("StopBrowse: removed retransmission for {}", &ty);
                                 continue;
                             }
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,7 +382,7 @@ impl ServiceDaemon {
     /// 4. announce its registered services.
     /// 5. process retransmissions if any.
     fn run(mut zc: Zeroconf, receiver: Receiver<Command>) {
-        let poller_key = 7;
+        let poller_key = 17;
         if let Err(e) = zc
             .poller
             .add(&zc.listen_socket, polling::Event::readable(poller_key))
@@ -396,7 +396,8 @@ impl ServiceDaemon {
         loop {
             events.clear();
             match zc.poller.wait(&mut events, Some(timeout)) {
-                Ok(count) => {
+                Ok(_) => {
+                    let count = events.iter().filter(|ev| ev.key == poller_key).count();
                     if count > 0 {
                         // Read until no more packets available.
                         loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1542,13 +1542,13 @@ impl ServiceInfo {
         self.other_ttl
     }
 
+    /// Returns whether the service info is ready to be resolved.
     fn is_ready(&self) -> bool {
         let some_missing = self.ty_domain.is_empty()
             || self.fullname.is_empty()
             || self.server.is_empty()
             || self.port == 0
-            || self.addresses.is_empty()
-            || self.properties.is_empty();
+            || self.addresses.is_empty();
         !some_missing
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,7 +382,7 @@ impl ServiceDaemon {
     /// 4. announce its registered services.
     /// 5. process retransmissions if any.
     fn run(mut zc: Zeroconf, receiver: Receiver<Command>) {
-        let poller_key = 17;
+        let poller_key = 17; // An arbitrary number to identify the events we are interested in.
         if let Err(e) = zc
             .poller
             .add(&zc.listen_socket, polling::Event::readable(poller_key))

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -109,7 +109,7 @@ fn integration_success() {
     }
 
     // Wait a bit to let the daemon process commands in the channel.
-    sleep(Duration::from_secs(1));
+    sleep(Duration::from_millis(1200));
 
     // Unregister the service
     let receiver = d.unregister(&fullname).unwrap();


### PR DESCRIPTION
see issue #18 . 

- Use `socket2` for cross-platform socket programming. 
- Use `polling` to support cross-platform polling / select.

If successful, will no longer use `nix`.

~~Pending considerations:~~
- `socket2` now has two branches `0.3` and `0.4`, and they use some different approaches.  We are using `0.3` branch because its socket [`recv_from`](https://docs.rs/socket2/0.3.19/socket2/struct.Socket.html#method.recv_from) method has better ergonomics, while `0.4` branch [ `recv_from`](https://docs.rs/socket2/0.4.4/socket2/struct.Socket.html#method.recv_from) uses `MayebUninit` which is hard to use. 

Update 2022-6-13:

- All things considered, I moved to the latest `socket2` (i.e. branch 0.4) because it will be easier to update / track in the future.  The trade-off is to use `Read` trait instead of `recv_from`, andwe will no longer log the peer address.