### PR TITLE
impl AsIpv4Addrs refactoring

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1395,6 +1395,12 @@ pub trait AsIpv4Addrs {
     fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>>;
 }
 
+impl<T: AsIpv4Addrs> AsIpv4Addrs for &T {
+    fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>> {
+        (*self).as_ipv4_addrs()
+    }
+}
+
 impl AsIpv4Addrs for &str {
     fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>> {
         let mut addrs = HashSet::new();
@@ -1414,7 +1420,7 @@ impl AsIpv4Addrs for &str {
     }
 }
 
-impl AsIpv4Addrs for &String {
+impl AsIpv4Addrs for String {
     fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>> {
         self.as_str().as_ipv4_addrs()
     }
@@ -1440,16 +1446,16 @@ impl AsIpv4Addrs for () {
     }
 }
 
-impl AsIpv4Addrs for &Ipv4Addr {
+impl AsIpv4Addrs for Ipv4Addr {
     fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>> {
         let mut ips = HashSet::new();
-        ips.insert(**self);
+        ips.insert(*self);
 
         Ok(ips)
     }
 }
 
-impl AsIpv4Addrs for &std::net::Ipv4Addr {
+impl AsIpv4Addrs for std::net::Ipv4Addr {
     fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>> {
         let mut ips = HashSet::new();
         ips.insert(Ipv4Addr::from_std(self));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1414,7 +1414,7 @@ impl AsIpv4Addrs for &str {
     }
 }
 
-impl AsIpv4Addrs for String {
+impl AsIpv4Addrs for &String {
     fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>> {
         self.as_str().as_ipv4_addrs()
     }
@@ -1440,16 +1440,16 @@ impl AsIpv4Addrs for () {
     }
 }
 
-impl AsIpv4Addrs for Ipv4Addr {
+impl AsIpv4Addrs for &Ipv4Addr {
     fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>> {
         let mut ips = HashSet::new();
-        ips.insert(*self);
+        ips.insert(**self);
 
         Ok(ips)
     }
 }
 
-impl AsIpv4Addrs for std::net::Ipv4Addr {
+impl AsIpv4Addrs for &std::net::Ipv4Addr {
     fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>> {
         let mut ips = HashSet::new();
         ips.insert(Ipv4Addr::from_std(self));

--- a/tests/addr_parse.rs
+++ b/tests/addr_parse.rs
@@ -1,8 +1,6 @@
-use std::collections::HashSet;
-use std::iter::FromIterator;
-
 use mdns_sd::AsIpv4Addrs;
 use nix::sys::socket::Ipv4Addr;
+use std::collections::HashSet;
 
 #[test]
 fn test_addr_str() {
@@ -18,7 +16,7 @@ fn test_addr_str() {
 
     let addr = "127.0.0.1".to_string();
     assert_eq!(
-        addr.as_ipv4_addrs(),
+        (&addr).as_ipv4_addrs(),
         Ok({
             let mut set = HashSet::new();
             set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 1)));
@@ -79,7 +77,7 @@ fn test_addr_ip() {
     let ip = std::net::Ipv4Addr::new(127, 0, 0, 1);
 
     assert_eq!(
-        ip.as_ipv4_addrs(),
+        (&ip).as_ipv4_addrs(),
         Ok({
             let mut set = HashSet::new();
             set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 1)));
@@ -89,7 +87,7 @@ fn test_addr_ip() {
     );
 
     assert_eq!(
-        Ipv4Addr::from_std(&ip).as_ipv4_addrs(),
+        (&Ipv4Addr::from_std(&ip)).as_ipv4_addrs(),
         Ok({
             let mut set = HashSet::new();
             set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 1)));

--- a/tests/addr_parse.rs
+++ b/tests/addr_parse.rs
@@ -16,6 +16,17 @@ fn test_addr_str() {
 
     let addr = "127.0.0.1".to_string();
     assert_eq!(
+        addr.as_ipv4_addrs(),
+        Ok({
+            let mut set = HashSet::new();
+            set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 1)));
+
+            set
+        })
+    );
+
+    // verify that `&String` also works.
+    assert_eq!(
         (&addr).as_ipv4_addrs(),
         Ok({
             let mut set = HashSet::new();
@@ -77,7 +88,7 @@ fn test_addr_ip() {
     let ip = std::net::Ipv4Addr::new(127, 0, 0, 1);
 
     assert_eq!(
-        (&ip).as_ipv4_addrs(),
+        ip.as_ipv4_addrs(),
         Ok({
             let mut set = HashSet::new();
             set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 1)));
@@ -87,7 +98,7 @@ fn test_addr_ip() {
     );
 
     assert_eq!(
-        (&Ipv4Addr::from_std(&ip)).as_ipv4_addrs(),
+        Ipv4Addr::from_std(&ip).as_ipv4_addrs(),
         Ok({
             let mut set = HashSet::new();
             set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 1)));


### PR DESCRIPTION
When trying to use the latest code in `main`, I found that it missed `impl AsIpv4Addrs` trait for `&String`, which I used with previous versions. 

To support `AsIpv4Addrs` with reference types and avoid redundancy,  this diff changes the rest of `impl`s to use reference types.

This is a follow-up to PR #21 .  @indietyp  any comments/thoughts?