### PR TITLE
prepare for a new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.5.0
+
+- Allow multiple formats for host_ipv4 to create ServiceInfo.
+- A breaking change: change `ServiceInfo::new()` to return a `Result<>`.
+
 # Version 0.4.3
 
 - Fix a bug in stop-browse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Allow multiple formats for host_ipv4 to create ServiceInfo.
 - A breaking change: change `ServiceInfo::new()` to return a `Result<>`.
+- Update `nix` dependency to version 0.24.1.
 
 # Version 0.4.3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ default = ["async"]
 [dependencies]
 flume = { version = "0.10", default-features = false } # channel between threads
 log = "0.4.14"                                         # logging
-nix = "0.23.1"                                         # socket APIs
+nix = "0.24.1"                                         # socket APIs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdns-sd"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["keepsimple <keepsimple@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1391,6 +1391,7 @@ impl DnsCache {
     }
 }
 
+/// This trait allows for parsing an input into a set of one or multiple [`Ipv4Addr`].
 pub trait AsIpv4Addrs {
     fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>>;
 }
@@ -1401,6 +1402,8 @@ impl<T: AsIpv4Addrs> AsIpv4Addrs for &T {
     }
 }
 
+/// Supports one address or multiple addresses separated by `,`.
+/// For example: "127.0.0.1,127.0.0.2"
 impl AsIpv4Addrs for &str {
     fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>> {
         let mut addrs = HashSet::new();
@@ -1426,6 +1429,7 @@ impl AsIpv4Addrs for String {
     }
 }
 
+/// Support slice. Example: &["127.0.0.1", "127.0.0.2"]
 impl<I: AsIpv4Addrs> AsIpv4Addrs for &[I] {
     fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>> {
         let mut addrs = HashSet::new();
@@ -1490,6 +1494,9 @@ impl ServiceInfo {
     ///
     /// `my_name` is the instance name, without the service type suffix.
     /// `properties` are optional key/value pairs for the service.
+    ///
+    /// `host_ipv4` can be one or more IPv4 addresses, in a type that implements
+    /// [`AsIpv4Addrs`] trait.
     ///
     /// The host TTL and other TTL are set to default values.
     pub fn new<Ip: AsIpv4Addrs>(

--- a/tests/addr_parse.rs
+++ b/tests/addr_parse.rs
@@ -1,6 +1,6 @@
 use mdns_sd::AsIpv4Addrs;
-use nix::sys::socket::Ipv4Addr;
 use std::collections::HashSet;
+use std::net::Ipv4Addr;
 
 #[test]
 fn test_addr_str() {
@@ -8,7 +8,7 @@ fn test_addr_str() {
         "127.0.0.1".as_ipv4_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 1)));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1));
 
             set
         })
@@ -19,7 +19,7 @@ fn test_addr_str() {
         addr.as_ipv4_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 1)));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1));
 
             set
         })
@@ -30,7 +30,7 @@ fn test_addr_str() {
         (&addr).as_ipv4_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 1)));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1));
 
             set
         })
@@ -40,8 +40,8 @@ fn test_addr_str() {
         "127.0.0.1,127.0.0.2".as_ipv4_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 1)));
-            set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 2)));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1));
+            set.insert(Ipv4Addr::new(127, 0, 0, 2));
 
             set
         })
@@ -54,7 +54,7 @@ fn test_addr_slice() {
         (&["127.0.0.1"][..]).as_ipv4_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 1)));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1));
 
             set
         })
@@ -64,8 +64,8 @@ fn test_addr_slice() {
         (&["127.0.0.1", "127.0.0.2"][..]).as_ipv4_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 1)));
-            set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 2)));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1));
+            set.insert(Ipv4Addr::new(127, 0, 0, 2));
 
             set
         })
@@ -75,8 +75,8 @@ fn test_addr_slice() {
         (&vec!["127.0.0.1", "127.0.0.2"][..]).as_ipv4_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 1)));
-            set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 2)));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1));
+            set.insert(Ipv4Addr::new(127, 0, 0, 2));
 
             set
         })
@@ -85,23 +85,23 @@ fn test_addr_slice() {
 
 #[test]
 fn test_addr_ip() {
-    let ip = std::net::Ipv4Addr::new(127, 0, 0, 1);
+    let ip = Ipv4Addr::new(127, 0, 0, 1);
 
     assert_eq!(
         ip.as_ipv4_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 1)));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1));
 
             set
         })
     );
 
     assert_eq!(
-        Ipv4Addr::from_std(&ip).as_ipv4_addrs(),
+        (&ip).as_ipv4_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::from_std(&std::net::Ipv4Addr::new(127, 0, 0, 1)));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1));
 
             set
         })


### PR DESCRIPTION
- Updated version to 0.5.0 due to a breaking change.

- Updated doc comments.

- Updated `nix` crate to 0.24.1,  the main benefit is:  its own `Ipv4Addr` is deprecated and we are using `std::net::Ipv4Addr` now.  This is good for our new trait `AsIpv4Addrs` .  cc @indietyp  as the trait is updated.