### PR TITLE
Join all interfaces to multicast

### DIFF
--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -520,13 +520,14 @@ impl Zeroconf {
         debug!("created listening socket: {:?}", &listen_socket);
 
         let group_addr = Ipv4Addr::new(224, 0, 0, 251);
-        listen_socket
-            .join_multicast_v4(&group_addr, &Ipv4Addr::new(0, 0, 0, 0))
-            .map_err(|e| e_fmt!("join multicast group: {}", e))?;
 
         // We create a socket for every outgoing IPv4 interface.
         let mut respond_sockets = Vec::new();
         for ipv4_addr in my_ipv4_addrs() {
+            listen_socket
+                .join_multicast_v4(&group_addr, &ipv4_addr)
+                .map_err(|e| e_fmt!("join multicast group: {}", e))?;
+
             let respond_socket = new_socket(ipv4_addr, udp_port, false)?;
             respond_sockets.push(respond_socket);
         }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -526,7 +526,7 @@ impl Zeroconf {
         for ipv4_addr in my_ipv4_addrs() {
             listen_socket
                 .join_multicast_v4(&group_addr, &ipv4_addr)
-                .map_err(|e| e_fmt!("join multicast group: {}", e))?;
+                .map_err(|e| e_fmt!("join multicast group on addr {}: {}", &ipv4_addr, e))?;
 
             let respond_socket = new_socket(ipv4_addr, udp_port, false)?;
             respond_sockets.push(respond_socket);


### PR DESCRIPTION
Fix multicast dgram listen on a multiple net interfaces platform.

If call [`join_multicast_v4()`](https://docs.rs/socket2/0.4.4/socket2/struct.Socket.html#method.join_multicast_v4:~:text=If%20it%E2%80%99s%20Ipv4Addr%3A%3AUNSPECIFIED%20(INADDR_ANY)%20then%20an%20appropriate%20interface%20is%20chosen%20by%20the%20system.) with `0.0.0.0` on Win10, a random interface will be choose. The `listen_socket` may not be able to receive multicast dgram.



Signed-off-by: fufesou <shuanglongchen@yeah.net>