### PR TITLE
track IPv4 interfaces with sockets to support multiple LANs

### DIFF
--- a/examples/register.rs
+++ b/examples/register.rs
@@ -9,7 +9,9 @@
 //! cargo run --example register _my-hello._udp.local. test1
 //!
 
+use if_addrs::{IfAddr, Ifv4Addr};
 use mdns_sd::{ServiceDaemon, ServiceInfo};
+use std::net::Ipv4Addr;
 
 fn main() {
     // Create a new mDNS daemon.
@@ -20,8 +22,8 @@ fn main() {
     let instance_name = std::env::args()
         .nth(2)
         .expect("require a instance_name as the 2nd argument");
-    let service_host_ipv4 = "192.168.1.111,192.168.1.112";
-    let service_hostname = "192.168.1.111.local.";
+    let my_addrs: Vec<Ipv4Addr> = my_ipv4_interfaces().iter().map(|i| i.ip).collect();
+    let service_hostname = "mdns-example.local.";
     let port = 3456;
 
     // Register a service.
@@ -29,7 +31,7 @@ fn main() {
         &service_type,
         &instance_name,
         service_hostname,
-        service_host_ipv4,
+        &my_addrs[..],
         port,
         None,
     )
@@ -44,4 +46,21 @@ fn main() {
     loop {
         std::thread::sleep(std::time::Duration::from_millis(100))
     }
+}
+
+fn my_ipv4_interfaces() -> Vec<Ifv4Addr> {
+    if_addrs::get_if_addrs()
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|i| {
+            if i.is_loopback() {
+                None
+            } else {
+                match i.addr {
+                    IfAddr::V4(ifv4) => Some(ifv4),
+                    _ => None,
+                }
+            }
+        })
+        .collect()
 }

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -4,7 +4,7 @@
 //! [DnsOutgoing] is the logic representation of an outgoing DNS packet.
 //! [DnsOutPacket] is the encoded packet for [DnsOutgoing].
 
-use crate::{service_info::valid_ipv4_on_intf, Error, Result, ServiceInfo};
+use crate::{Error, Result, ServiceInfo};
 use if_addrs::Ifv4Addr;
 use log::{debug, error};
 use std::{any::Any, cmp, collections::HashMap, fmt, net::Ipv4Addr, str, time::SystemTime};
@@ -717,16 +717,13 @@ impl DnsOutgoing {
             service.generate_txt(),
         )));
 
-        for address in service.get_addresses() {
-            if !valid_ipv4_on_intf(address, intf) {
-                continue;
-            }
+        for address in service.get_addrs_on_intf(intf) {
             self.add_additional_answer(Box::new(DnsAddress::new(
                 service.get_hostname(),
                 TYPE_A,
                 CLASS_IN | CLASS_UNIQUE,
                 service.get_host_ttl(),
-                *address,
+                address,
             )));
         }
     }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -370,7 +370,6 @@ impl ServiceDaemon {
                     Some((_k, info)) => {
                         for i in 0..zc.intf_socks.len() {
                             let packet = zc.unregister_service(&info, &zc.intf_socks[i]);
-                            zc.increase_counter(Counter::Unregister, 1);
                             // repeat for one time just in case some peers miss the message
                             if !repeating && !packet.is_empty() {
                                 let next_time = current_time_millis() + 120;
@@ -380,6 +379,7 @@ impl ServiceDaemon {
                                 });
                             }
                         }
+                        zc.increase_counter(Counter::Unregister, 1);
                         UnregisterStatus::OK
                     }
                 };

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -471,7 +471,7 @@ struct IntfSock {
 
 /// A struct holding the state. It was inspired by `zeroconf` package in Python.
 struct Zeroconf {
-    // respond_sockets: HashMap<Ifv4Addr, Socket>,
+    /// Local interfaces with sockets to recv/send on these interfaces.
     intf_socks: Vec<IntfSock>,
 
     /// Local registered services

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -1,4 +1,5 @@
 use crate::{Error, Result};
+use if_addrs::Ifv4Addr;
 use log::error;
 use std::{
     collections::{HashMap, HashSet},
@@ -292,12 +293,20 @@ fn decode_txt(txt: &[u8]) -> HashMap<String, String> {
 }
 
 /// Returns a tuple of (service_type_domain, optional_sub_domain)
-pub fn split_sub_domain(domain: &str) -> (&str, Option<&str>) {
+pub(crate) fn split_sub_domain(domain: &str) -> (&str, Option<&str>) {
     if let Some((_, ty_domain)) = domain.rsplit_once("._sub.") {
         (ty_domain, Some(domain))
     } else {
         (domain, None)
     }
+}
+
+/// Returns true if `addr` is in the same network of `intf`.
+pub(crate) fn valid_ipv4_on_intf(addr: &Ipv4Addr, intf: &Ifv4Addr) -> bool {
+    let netmask = u32::from(intf.netmask);
+    let intf_net = u32::from(intf.ip) & netmask;
+    let addr_net = u32::from(*addr) & netmask;
+    addr_net == intf_net
 }
 
 #[cfg(test)]

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -156,6 +156,16 @@ impl ServiceInfo {
         self.weight
     }
 
+    /// Returns a list of addresses that are in the same LAN as
+    /// the interface `intf`.
+    pub(crate) fn get_addrs_on_intf(&self, intf: &Ifv4Addr) -> Vec<Ipv4Addr> {
+        self.addresses
+            .iter()
+            .filter(|a| valid_ipv4_on_intf(a, intf))
+            .copied()
+            .collect()
+    }
+
     /// Returns whether the service info is ready to be resolved.
     pub(crate) fn is_ready(&self) -> bool {
         let some_missing = self.ty_domain.is_empty()

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1,9 +1,10 @@
+use if_addrs::{IfAddr, Ifv4Addr};
+use mdns_sd::{Error, ServiceDaemon, ServiceEvent, ServiceInfo, UnregisterStatus};
 use std::collections::HashMap;
+use std::net::Ipv4Addr;
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::{Duration, SystemTime};
-
-use mdns_sd::{Error, ServiceDaemon, ServiceEvent, ServiceInfo, UnregisterStatus};
 
 /// This test covers:
 /// register(announce), browse(query), response, unregister, shutdown.
@@ -18,8 +19,10 @@ fn integration_success() {
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
     let instance_name = now.as_micros().to_string(); // Create a unique name.
-    let host_ipv4 = "192.168.1.12";
-    let host_name = "192.168.1.12.";
+
+    let my_ifaddrs = my_ipv4_interfaces();
+    let host_ipv4 = my_ifaddrs[0].ip.to_string();
+    let host_name = "my_host.";
     let port = 5200;
     let mut properties = HashMap::new();
     properties.insert("property_1".to_string(), "test".to_string());
@@ -30,7 +33,7 @@ fn integration_success() {
         ty_domain,
         &instance_name,
         host_name,
-        host_ipv4,
+        &host_ipv4,
         port,
         Some(properties),
     )
@@ -190,7 +193,7 @@ fn integration_success() {
 }
 
 #[test]
-fn service_without_properties() {
+fn service_without_properties_with_multi_ips() {
     // Create a daemon
     let d = ServiceDaemon::new().expect("Failed to create daemon");
 
@@ -200,11 +203,22 @@ fn service_without_properties() {
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
     let instance_name = now.as_micros().to_string(); // Create a unique name.
-    let host_ipv4 = "192.168.1.13";
-    let host_name = "192.168.1.13.";
+    let ifv4_addrs = &my_ipv4_interfaces();
+    let first_ipv4 = ifv4_addrs[0].ip;
+    let new_ipv4 = ipv4_next(&first_ipv4);
+    let alter_ipv4 = ipv4_alter_net(ifv4_addrs);
+    let host_ipv4 = vec![first_ipv4, new_ipv4, alter_ipv4];
+    let host_name = "my_host.";
     let port = 5201;
-    let my_service = ServiceInfo::new(ty_domain, &instance_name, host_name, host_ipv4, port, None)
-        .expect("valid service info");
+    let my_service = ServiceInfo::new(
+        ty_domain,
+        &instance_name,
+        host_name,
+        &host_ipv4[..],
+        port,
+        None,
+    )
+    .expect("valid service info");
     let fullname = my_service.get_fullname().to_string();
     d.register(my_service)
         .expect("Failed to register our service");
@@ -216,8 +230,14 @@ fn service_without_properties() {
         match browse_chan.recv_timeout(timeout) {
             Ok(event) => match event {
                 ServiceEvent::ServiceResolved(info) => {
-                    println!("Resolved a service of {}", &info.get_fullname());
+                    println!(
+                        "Resolved a service of {} addr(s): {:?}",
+                        &info.get_fullname(),
+                        info.get_addresses()
+                    );
                     assert_eq!(fullname.as_str(), info.get_fullname());
+                    let addrs = info.get_addresses();
+                    assert_eq!(addrs.len(), 2); // first_ipv4 and new_ipv4, but no alter_ipv4.
                     break;
                 }
                 e => {
@@ -246,14 +266,14 @@ fn subtype() {
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
     let instance_name = now.as_micros().to_string(); // Create a unique name.
-    let host_ipv4 = "192.168.1.13";
-    let host_name = "192.168.1.13.";
+    let host_ipv4 = my_ipv4_interfaces()[0].ip.to_string();
+    let host_name = "my_host.";
     let port = 5201;
     let my_service = ServiceInfo::new(
         subtype_domain,
         &instance_name,
         host_name,
-        host_ipv4,
+        &host_ipv4,
         port,
         None,
     )
@@ -287,4 +307,40 @@ fn subtype() {
     }
 
     d.shutdown().unwrap();
+}
+
+fn my_ipv4_interfaces() -> Vec<Ifv4Addr> {
+    if_addrs::get_if_addrs()
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|i| {
+            if i.is_loopback() {
+                None
+            } else {
+                match i.addr {
+                    IfAddr::V4(ifv4) => Some(ifv4),
+                    _ => None,
+                }
+            }
+        })
+        .collect()
+}
+
+fn ipv4_alter_net(ifv4_addrs: &Vec<Ifv4Addr>) -> Ipv4Addr {
+    let mut net_max = 0;
+    for ifv4_addr in ifv4_addrs.iter() {
+        let net = ifv4_addr.ip.octets()[0];
+        if net > net_max {
+            net_max = net;
+        }
+    }
+    Ipv4Addr::new(net_max + 1, 1, 1, 1)
+}
+
+fn ipv4_next(ipv4: &Ipv4Addr) -> Ipv4Addr {
+    let octets = ipv4.octets();
+    let last_octet = octets[3];
+    let new_octet = if last_octet < 255 { last_octet + 1 } else { 1 };
+
+    Ipv4Addr::new(octets[0], octets[1], octets[2], new_octet)
 }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -148,7 +148,7 @@ fn integration_success() {
     assert_eq!(metrics["register"], 1);
     assert_eq!(metrics["unregister"], 1);
     assert_eq!(metrics["register-resend"], 1);
-    assert_eq!(metrics["unregister-resend"], 1);
+    assert_eq!(metrics["unregister-resend"], my_ifaddrs.len() as i64);
     assert!(metrics["browse"] >= 2); // browse has been retransmitted.
     assert!(metrics["respond"] >= 2); // respond has been sent for every browse.
 

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -21,6 +21,8 @@ fn integration_success() {
     let instance_name = now.as_micros().to_string(); // Create a unique name.
 
     let my_ifaddrs = my_ipv4_interfaces();
+    println!("My IPv4 addr(s): {:?}", &my_ifaddrs);
+
     let host_ipv4 = my_ifaddrs[0].ip.to_string();
     let host_name = "my_host.";
     let port = 5200;


### PR DESCRIPTION
Fix the issue #46 .   (It might also help fixing #47, need testing ) 

- Use a new struct `IntfSock` to link the interface with the socket.
- Only include the DNS `A` record of the same LAN as the outgoing interface.
- Use the same socket for receiving and sending on an interface.