### PR TITLE
call check_service_name before sending the cmd to the daemon.

### DIFF
--- a/examples/query.rs
+++ b/examples/query.rs
@@ -27,17 +27,23 @@ fn main() {
     service_type.push_str(".local.");
     let receiver = mdns.browse(&service_type).expect("Failed to browse");
 
+    let now = std::time::Instant::now();
     while let Ok(event) = receiver.recv() {
         match event {
             ServiceEvent::ServiceResolved(info) => {
                 println!(
-                    "Resolved a new service: {} IP: {:?}",
+                    "At {:?}: Resolved a new service: {} IP: {:?}",
+                    now.elapsed(),
                     info.get_fullname(),
                     info.get_addresses()
                 );
             }
             other_event => {
-                println!("Received other event: {:?}", &other_event);
+                println!(
+                    "At {:?} : Received other event: {:?}",
+                    now.elapsed(),
+                    &other_event
+                );
             }
         }
     }

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -64,7 +64,9 @@ pub(crate) struct DnsQuestion {
     pub(crate) entry: DnsEntry,
 }
 
-/// A DNS record - like a DNS entry, but has a TTL
+/// A DNS Resource Record - like a DNS entry, but has a TTL.
+/// RFC: https://www.rfc-editor.org/rfc/rfc1035#section-3.2.1
+///      https://www.rfc-editor.org/rfc/rfc1035#section-4.1.3
 #[derive(Debug)]
 pub(crate) struct DnsRecord {
     pub(crate) entry: DnsEntry,
@@ -94,7 +96,7 @@ impl DnsRecord {
     }
 
     /// Updates the refresh time to be the same as the expire time so that
-    /// there is no more refresh for this record.
+    /// this record will not refresh again and will just expire.
     pub(crate) fn refresh_no_more(&mut self) {
         self.refresh = get_expiration_time(self.created, self.ttl, 100);
     }


### PR DESCRIPTION
Currently `check_service_name` is called in the daemon thread, after receiving cmd from a client. If it fails, it will be a silent error for the client. To fix this, call the check before sending the cmd to the daemon thread. Also added a test case for this check.

Also included a few minor refactoring, e.g. added timestamp in `examples/query.rs`.