### PR TITLE
configure mDNS daemon thread a name

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 /// A basic error type from this library.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// Like a classic EAGAIN. The receiver should retry.

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -124,7 +124,10 @@ impl ServiceDaemon {
         let (sender, receiver) = bounded(100);
 
         // Spawn the daemon thread
-        thread::spawn(move || Self::run(zc, receiver));
+        thread::Builder::new()
+            .name("mDNS_daemon".to_string())
+            .spawn(move || Self::run(zc, receiver))
+            .map_err(|e| e_fmt!("thread builder failed to spawn: {}", e))?;
 
         Ok(Self { sender })
     }


### PR DESCRIPTION
A thread name can help debugging a running application using this library.