### PR TITLE
Use CaseInsesitiveHashMap for TXT keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ logging = ["log"]
 default = ["async", "logging"]
 
 [dependencies]
+case_insensitive_hashmap = "1.0.0"
 flume = { version = "0.10", default-features = false } # channel between threads
 if-addrs = "0.7"                                       # get local IP addresses
 log = { version = "0.4.14", optional = true }          # logging

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //!
 //! ```rust
 //! use mdns_sd::{ServiceDaemon, ServiceInfo};
-//! use std::collections::HashMap;
+//! use case_insensitive_hashmap::CaseInsensitiveHashMap;
 //!
 //! // Create a daemon
 //! let mdns = ServiceDaemon::new().expect("Failed to create daemon");
@@ -73,7 +73,7 @@
 //! let host_ipv4 = "192.168.1.12";
 //! let host_name = "192.168.1.12.local.";
 //! let port = 5200;
-//! let mut properties = HashMap::new();
+//! let mut properties = CaseInsensitiveHashMap::new();
 //! properties.insert("property_1".to_string(), "test".to_string());
 //! properties.insert("property_2".to_string(), "1234".to_string());
 //!

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1,6 +1,6 @@
+use case_insensitive_hashmap::CaseInsensitiveHashMap;
 use if_addrs::{IfAddr, Ifv4Addr};
 use mdns_sd::{Error, ServiceDaemon, ServiceEvent, ServiceInfo, UnregisterStatus};
-use std::collections::HashMap;
 use std::net::Ipv4Addr;
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
@@ -26,9 +26,9 @@ fn integration_success() {
     let host_ipv4 = my_ifaddrs[0].ip.to_string();
     let host_name = "my_host.";
     let port = 5200;
-    let mut properties = HashMap::new();
+    let mut properties = CaseInsensitiveHashMap::new();
     properties.insert("property_1".to_string(), "test".to_string());
-    properties.insert("property_2".to_string(), "1".to_string());
+    properties.insert("PROPERTY_2".to_string(), "1".to_string());
     properties.insert("property_3".to_string(), "1234".to_string());
 
     let my_service = ServiceInfo::new(


### PR DESCRIPTION
The RFC requires TXT keys to be case insensitive.

This simply replaces `HashMap<String, String>`
with `CaseInsensitiveHashMap<String>`.