### PR TITLE
skip interfaces that failed to bind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ if-addrs = "0.7"                                       # get local IP addresses
 log = { version = "0.4.14", optional = true }          # logging
 polling = "2.1.0"                                      # select/poll sockets
 socket2 = { version = "0.4", features = ["all"] }      # socket APIs
+
+[dev-dependencies]
+fastrand = "1.8"

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -763,16 +763,12 @@ impl DnsOutgoing {
 
             let mut auth_count = 0;
             for auth in self.authorities.iter() {
-                auth_count += if packet.write_record(auth, 0) { 1 } else { 0 };
+                auth_count += u16::from(packet.write_record(auth, 0));
             }
 
             let mut addi_count = 0;
             for addi in self.additionals.iter() {
-                addi_count += if packet.write_record(addi.as_ref(), 0) {
-                    1
-                } else {
-                    0
-                };
+                addi_count += u16::from(packet.write_record(addi.as_ref(), 0));
             }
 
             packet.state = PacketState::Finished;

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -532,7 +532,13 @@ impl Zeroconf {
         // Create a socket for every IPv4 interface.
         let mut intf_socks = Vec::new();
         for intf in my_ifv4addrs {
-            let sock = new_socket_bind(&intf.ip)?;
+            let sock = match new_socket_bind(&intf.ip) {
+                Ok(s) => s,
+                Err(e) => {
+                    error!("bind a socket to {}: {}", &intf.ip, e);
+                    continue;
+                }
+            };
             intf_socks.push(IntfSock { intf, sock });
         }
 
@@ -786,10 +792,13 @@ impl Zeroconf {
             }
 
             // Replace the closed socket with a new one.
-            if let Ok(sock) = new_socket_bind(&intf_sock.intf.ip) {
-                let intf = intf_sock.intf.clone();
-                self.replace_intf_sock(idx, IntfSock { intf, sock });
-                debug!("reset socket at idx {}", idx);
+            match new_socket_bind(&intf_sock.intf.ip) {
+                Ok(sock) => {
+                    let intf = intf_sock.intf.clone();
+                    self.replace_intf_sock(idx, IntfSock { intf, sock });
+                    debug!("reset socket at idx {}", idx);
+                }
+                Err(e) => error!("re-bind a socket to {}: {}", &intf_sock.intf.ip, e),
             }
             return false;
         }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -535,7 +535,7 @@ impl Zeroconf {
             let sock = match new_socket_bind(&intf.ip) {
                 Ok(s) => s,
                 Err(e) => {
-                    error!("bind a socket to {}: {}", &intf.ip, e);
+                    error!("bind a socket to {}: {}. Skipped.", &intf.ip, e);
                     continue;
                 }
             };

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -228,6 +228,7 @@ fn service_without_properties_with_alter_net() {
     let fullname = my_service.get_fullname().to_string();
     d.register(my_service)
         .expect("Failed to register our service");
+    println!("Registered service with host_ipv4: {:?}", &host_ipv4);
 
     // Browse for a service
     let browse_chan = d.browse(ty_domain).unwrap();
@@ -405,6 +406,9 @@ fn service_name_check() {
 }
 
 fn my_ipv4_interfaces() -> Vec<Ifv4Addr> {
+    // Use a random port for binding test.
+    let test_port = fastrand::u16(8000u16..9000u16);
+
     if_addrs::get_if_addrs()
         .unwrap_or_default()
         .into_iter()
@@ -413,7 +417,15 @@ fn my_ipv4_interfaces() -> Vec<Ifv4Addr> {
                 None
             } else {
                 match i.addr {
-                    IfAddr::V4(ifv4) => Some(ifv4),
+                    IfAddr::V4(ifv4) =>
+                    // Use a 'bind' to check if this is a valid IPv4 addr.
+                    {
+                        match std::net::UdpSocket::bind((ifv4.ip, test_port)) {
+                            Ok(_) => Some(ifv4),
+                            Err(_) => None,
+                        }
+                    }
+
                     _ => None,
                 }
             }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -422,10 +422,12 @@ fn my_ipv4_interfaces() -> Vec<Ifv4Addr> {
                     {
                         match std::net::UdpSocket::bind((ifv4.ip, test_port)) {
                             Ok(_) => Some(ifv4),
-                            Err(_) => None,
+                            Err(e) => {
+                                println!("Not able to bind {}: {}", ifv4.ip, e);
+                                None
+                            }
                         }
                     }
-
                     _ => None,
                 }
             }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -423,7 +423,7 @@ fn my_ipv4_interfaces() -> Vec<Ifv4Addr> {
                         match std::net::UdpSocket::bind((ifv4.ip, test_port)) {
                             Ok(_) => Some(ifv4),
                             Err(e) => {
-                                println!("Not able to bind {}: {}", ifv4.ip, e);
+                                println!("bind {}: {}, skipped.", ifv4.ip, e);
                                 None
                             }
                         }


### PR DESCRIPTION
This is to fix  #78. It seems that we lost commit [`f888b8fb94b4cc2002f451b858937fbde5b453bc`](https://github.com/keepsimple1/mdns-sd/commit/f888b8fb94b4cc2002f451b858937fbde5b453bc) during refactoring. Now we are fixing it again ;-).

Also fixed clippy errors with Rust 1.66.