### PR TITLE
support host IP changes

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -654,7 +654,8 @@ impl DnsOutgoing {
     }
 
     /// Returns true if `answer` is added to the outgoing msg.
-    /// Returns false if the answer expired hence not added.
+    /// Returns false if the answer is expired `now` hence not added.
+    /// If `now` is 0, do not check if the answer expires.
     pub(crate) fn add_answer_at_time(&mut self, answer: Box<dyn DnsRecordExt>, now: u64) -> bool {
         debug!("Check for add_answer_at_time");
         if now == 0 || !answer.get_record().is_expired(now) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,6 @@
 //! We focus on the common use cases at first, and currently have the following limitations:
 //! - Only support IPv4, not IPv6.
 //! - Only support multicast, not unicast send/recv.
-//! - Only tested on Linux and MacOS, not on Windows or other OSes.
 
 #![forbid(unsafe_code)]
 #![allow(clippy::single_component_path_imports)]

--- a/tests/addr_parse.rs
+++ b/tests/addr_parse.rs
@@ -46,6 +46,9 @@ fn test_addr_str() {
             set
         })
     );
+
+    // verify that an empty string parsed into an empty set.
+    assert_eq!("".as_ipv4_addrs(), Ok(HashSet::new()));
 }
 
 #[test]

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -435,6 +435,11 @@ fn my_ipv4_interfaces() -> Vec<Ifv4Addr> {
         .collect()
 }
 
+/// Returns a made-up IPv4 address "net.1.1.1", where
+/// `net` is one higher than any of IPv4 addresses on the host.
+///
+/// The idea is that this made-up address does not belong to
+/// the same network as any of the host addresses.
 fn ipv4_alter_net(ifv4_addrs: &Vec<Ifv4Addr>) -> Ipv4Addr {
     let mut net_max = 0;
     for ifv4_addr in ifv4_addrs.iter() {


### PR DESCRIPTION
When host IP changes, including adding or removing an IP address, mDNS daemon needs to update its listening sockets (`poller`) and its registered services (if desired). This patch implements:

- Detecting host IP changes periodically (every 2 seconds).
- When IP is added or removed, update the poller sockets.
- A new attribute in `ServiceInfo`: `addr_auto`. When `addr_auto` is enabled, the lib will update IP addresses of a registered service automatically. This also means if `register()` calls with empty addresses, the lib will fill in automatically.
- A new `ServiceDaemon::monitor()` method to return a `Receiver` handle to monitor the daemon events, such as IP changes.
