### PR TITLE
Txt properties' names should be case insensitive.

### DIFF
--- a/examples/query.rs
+++ b/examples/query.rs
@@ -32,10 +32,11 @@ fn main() {
         match event {
             ServiceEvent::ServiceResolved(info) => {
                 println!(
-                    "At {:?}: Resolved a new service: {} IP: {:?}",
+                    "At {:?}: Resolved a new service: {} IP: {:?} TXT properties: {:?}",
                     now.elapsed(),
                     info.get_fullname(),
-                    info.get_addresses()
+                    info.get_addresses(),
+                    info.get_properties(),
                 );
             }
             other_event => {

--- a/examples/register.rs
+++ b/examples/register.rs
@@ -27,6 +27,10 @@ fn main() {
     let service_hostname = "mdns-example.local.";
     let port = 3456;
 
+    // The key string in TXT properties is case insensitive. Only the first
+    // (key, val) pair will take effect.
+    let properties = vec![("PATH", "one"), ("Path", "two"), ("PaTh", "three")];
+
     // Register a service.
     let service_info = ServiceInfo::new(
         &service_type,
@@ -34,7 +38,7 @@ fn main() {
         service_hostname,
         my_addrs,
         port,
-        None,
+        &properties[..],
     )
     .expect("valid service info")
     .enable_addr_auto();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,9 +73,7 @@
 //! let host_ipv4 = "192.168.1.12";
 //! let host_name = "192.168.1.12.local.";
 //! let port = 5200;
-//! let mut properties = HashMap::new();
-//! properties.insert("property_1".to_string(), "test".to_string());
-//! properties.insert("property_2".to_string(), "1234".to_string());
+//! let properties = [("property_1", "test"), ("property_2", "1234")];
 //!
 //! let my_service = ServiceInfo::new(
 //!     service_type,
@@ -83,7 +81,7 @@
 //!     host_name,
 //!     host_ipv4,
 //!     port,
-//!     Some(properties),
+//!     &properties[..],
 //! ).unwrap();
 //!
 //! // Register with the daemon, which publishes the service.
@@ -124,8 +122,8 @@ mod service_daemon;
 mod service_info;
 
 pub use error::{Error, Result};
-pub use service_daemon::{Metrics, ServiceDaemon, ServiceEvent, UnregisterStatus};
-pub use service_info::{AsIpv4Addrs, ServiceInfo};
+pub use service_daemon::{DaemonEvent, Metrics, ServiceDaemon, ServiceEvent, UnregisterStatus};
+pub use service_info::{AsIpv4Addrs, IntoTxtProperties, ServiceInfo, TxtProperties, TxtProperty};
 
 /// A handler to receive messages from [ServiceDaemon]. Re-export from `flume` crate.
 pub use flume::Receiver;

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1410,7 +1410,8 @@ impl Zeroconf {
     }
 }
 
-/// All possible events sent to the client from the daemon.
+/// All possible events sent to the client from the daemon
+/// regarding service discovery.
 #[derive(Debug)]
 pub enum ServiceEvent {
     /// Started searching for a service type.


### PR DESCRIPTION
This is an attempt to fix issue #76 without adding external dependencies. Prior PR:  https://github.com/keepsimple1/mdns-sd/pull/77

- TXT properties are indexed by their names with lower case (i.e. case insensitive).
- TXT properties also keep their original name in `TxtProperty` struct or the returned `HashMap<String, String>` .

Added a new trait `IntoTxtProperties` to support case insensitive property names, and to support more ergnomical inputs. Also be backward compatible when possible.
