### PR TITLE
send a test multicast packet when binding a socket to an IP

### DIFF
--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -500,6 +500,11 @@ fn new_socket_bind(intf_ip: &Ipv4Addr) -> Result<Socket> {
     sock.set_multicast_if_v4(intf_ip)
         .map_err(|e| e_fmt!("set multicast_if on addr {}: {}", intf_ip, e))?;
 
+    // Test if we can send packets successfully.
+    let multicast_addr = SocketAddrV4::new(GROUP_ADDR, MDNS_PORT).into();
+    sock.send_to("hello".as_bytes(), &multicast_addr)
+        .map_err(|e| e_fmt!("send multicast packet on addr {}: {}", intf_ip, e))?;
+
     Ok(sock)
 }
 


### PR DESCRIPTION
This is to solve issue #83 . The idea is that we send out a test packet when creating a socket binding to a local address. If the send fails, we will not use this address to send & receive mDNS packets.