### PR TITLE
change intf_socks from Vec to HashMap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@
 //! We focus on the common use cases at first, and currently have the following limitations:
 //! - Only support IPv4, not IPv6.
 //! - Only support multicast, not unicast send/recv.
+//! - Only support 32-bit or bigger platforms, not 16-bit platforms.
 
 #![forbid(unsafe_code)]
 #![allow(clippy::single_component_path_imports)]

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -255,6 +255,8 @@ impl ServiceDaemon {
     /// 5. process retransmissions if any.
     fn run(mut zc: Zeroconf, receiver: Receiver<Command>) {
         for (ipv4, if_sock) in zc.intf_socks.iter() {
+            // It is OK to convert to `usize` here as we only support 32-bit
+            // or 64-bit platforms.
             let key = u32::from(*ipv4) as usize;
             if let Err(e) = zc.poller.add(&if_sock.sock, polling::Event::readable(key)) {
                 error!("add socket of {:?} to poller: {}", ipv4, e);
@@ -282,7 +284,7 @@ impl ServiceDaemon {
                                 .poller
                                 .modify(&intf_sock.sock, polling::Event::readable(ev.key))
                             {
-                                error!("failed to poll listen_socket again: {}", e);
+                                error!("modify poller for IP {}: {}", &ipv4, e);
                                 break;
                             }
                         }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -934,14 +934,14 @@ impl Zeroconf {
         }
     }
 
-    /// Reads from the socket in self.intf_socks[idx].
+    /// Reads from the socket of `ipv4`.
     ///
     /// Returns false if failed to receive a packet,
     /// otherwise returns true.
     fn handle_read(&mut self, ipv4: &Ipv4Addr) -> bool {
         let intf_sock = match self.intf_socks.get_mut(ipv4) {
             Some(if_sock) => if_sock,
-            None => return true,
+            None => return false,
         };
         let mut buf = vec![0u8; MAX_MSG_ABSOLUTE];
         let sz = match intf_sock.sock.read(&mut buf) {


### PR DESCRIPTION
The trigger for this patch is an out-of-bound indexing panic observed, but not reproduced, and without a stacktrace:

```
Jan 27 19:38:29: thread 'mDNS_daemon' panicked at 'range end index 4 out of range for slice of length 3', library/core/src/slice/index.rs:73:5
Jan 27 19:38:29: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.

```

I suspect this panic is related to [recent changes](https://github.com/keepsimple1/mdns-sd/commit/05dd53931d9d1d28aff74b34f81c0e5484cd37b3) to modifying `intf_socks` when IP address changes are detected. I think the use of indexing of `intf_socks` Vec is inherently fragile, so I wanted to change it to a `HashMap`. 

The only caveat is that the socket `poller` uses a key of `usize` type, which in theory could be < 32bit. But in practice, all the platforms we are supporting are at least 32 bits. I think it's OK to convert IPv4 into the key for the poller. 

Btw, there is no change to public APIs.