### PR TITLE
refactoring `get_properties` and `TxtProperties`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = ["async", "logging"]
 flume = { version = "0.10", default-features = false } # channel between threads
 if-addrs = "0.7"                                       # get local IP addresses
 log = { version = "0.4.14", optional = true }          # logging
-polling = "2.4"                                        # select/poll sockets
+polling = "2.1"                                        # select/poll sockets
 socket2 = { version = "0.4", features = ["all"] }      # socket APIs
 
 [dev-dependencies]

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -342,6 +342,11 @@ impl TxtProperties {
         self.properties.len()
     }
 
+    /// Returns if the properties are empty.
+    pub fn is_empty(&self) -> bool {
+        self.properties.is_empty()
+    }
+
     /// Returns a property for a given `key`, where `key` is
     /// case insensitive.
     pub fn get(&self, key: &str) -> Option<&TxtProperty> {

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -46,8 +46,7 @@ impl ServiceInfo {
     /// implements [`IntoTxtProperties`] trait. It supports:
     /// - `HashMap<String, String>`
     /// - `Option<HashMap<String, String>>`
-    /// - `&[(&str, &str)]`
-    /// - `&[(String, String)]`
+    /// - slice of tuple: `&[(K, V)]` where `K` and `V` are [`std::string::ToString`].
     ///
     /// `host_ipv4` can be one or more IPv4 addresses, in a type that implements
     /// [`AsIpv4Addrs`] trait. It supports:

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1,5 +1,7 @@
 use if_addrs::{IfAddr, Ifv4Addr};
-use mdns_sd::{Error, ServiceDaemon, ServiceEvent, ServiceInfo, UnregisterStatus};
+use mdns_sd::{
+    Error, IntoTxtProperties, ServiceDaemon, ServiceEvent, ServiceInfo, UnregisterStatus,
+};
 use std::collections::HashMap;
 use std::net::Ipv4Addr;
 use std::sync::{Arc, Mutex};
@@ -294,6 +296,19 @@ fn service_txt_properties_case_insensitive() {
     // Verify the original property name is kept.
     let prop_mixed = my_service.get_property("prop_cap_lower").unwrap();
     assert_eq!(prop_mixed.key(), "prop_Cap_Lower");
+}
+
+#[test]
+fn test_into_txt_properties() {
+    // Verify (&str, String) tuple is supported.
+    let properties = vec![("key1", String::from("val1"))];
+    let txt_props = properties.into_txt_properties();
+    assert_eq!(txt_props.get_property_val("key1").unwrap(), "val1");
+
+    // Verify (String, String) tuple is supported.
+    let properties = vec![(String::from("key2"), String::from("val2"))];
+    let txt_props = properties.into_txt_properties();
+    assert_eq!(txt_props.get_property_val("key2").unwrap(), "val2");
 }
 
 #[test]


### PR DESCRIPTION
- Added `iter()` for `TxtProperties`, with a bonus benefit: more compatible with previous API.
- impl `From<(K, V)>`  for generic `(K, V)` .