### PR TITLE
check for proper characters in TXT keys

### DIFF
--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -75,6 +75,25 @@ impl ServiceInfo {
         let txt_properties = properties.into_txt_properties();
         let last_update = current_time_millis();
 
+        // RFC6763 section 6.4: https://www.rfc-editor.org/rfc/rfc6763#section-6.4
+        // The characters of a key MUST be printable US-ASCII values (0x20-0x7E)
+        // [RFC20], excluding '=' (0x3D).
+        for prop in txt_properties.iter() {
+            let key = prop.key();
+            if !key.is_ascii() {
+                return Err(Error::Msg(format!(
+                    "TXT property key {} is not ASCII",
+                    prop.key()
+                )));
+            }
+            if key.contains('=') {
+                return Err(Error::Msg(format!(
+                    "TXT property key {} contains '='",
+                    prop.key()
+                )));
+            }
+        }
+
         let this = Self {
             ty_domain,
             sub_domain,

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -301,6 +301,36 @@ fn service_txt_properties_case_insensitive() {
 }
 
 #[test]
+fn service_txt_properties_key_ascii() {
+    let domain = "_mdns-ascii._tcp.local.";
+    let instance = "test_service_info_key_ascii";
+    let port = 5202;
+
+    // Verify that a key must contain ASCII only. E.g. cannot have emojis.
+    let properties = [("prop_ascii", "one"), ("prop_🤗", "hugging_face")];
+    let my_service = ServiceInfo::new(domain, instance, "myhost", "", port, &properties[..]);
+    assert!(my_service.is_err());
+    if let Err(e) = my_service {
+        let msg = format!("ERROR: {}", e);
+        assert!(msg.contains("not ASCII"));
+    }
+
+    // Verify that a key cannot contain '='.
+    let properties = [("prop_ascii", "one"), ("prop_=", "equal sign")];
+    let my_service = ServiceInfo::new(domain, instance, "myhost", "", port, &properties[..]);
+    assert!(my_service.is_err());
+    if let Err(e) = my_service {
+        let msg = format!("ERROR: {}", e);
+        assert!(msg.contains("="));
+    }
+
+    // Verify that properly formatted keys are OK.
+    let properties = [("prop_ascii", "one"), ("prop_2", "two")];
+    let my_service = ServiceInfo::new(domain, instance, "myhost", "", port, &properties[..]);
+    assert!(my_service.is_ok());
+}
+
+#[test]
 fn test_into_txt_properties() {
     // Verify (&str, String) tuple is supported.
     let properties = vec![("key1", String::from("val1"))];


### PR DESCRIPTION
This is to solve one of the issues in #71 : 

```
Rules for Keys in DNS-SD Key/Value Pairs

The characters of a key MUST be printable US-ASCII values (0x20-0x7E)
[RFC20], excluding '=' (0x3D).
```