### PR TITLE
impl Display for TxtProperties

### DIFF
--- a/examples/query.rs
+++ b/examples/query.rs
@@ -37,7 +37,7 @@ fn main() {
         match event {
             ServiceEvent::ServiceResolved(info) => {
                 println!(
-                    "At {:?}: Resolved a new service: {} IP: {:?} TXT properties: {:?}",
+                    "At {:?}: Resolved a new service: {} IP: {:?} TXT properties: {}",
                     now.elapsed(),
                     info.get_fullname(),
                     info.get_addresses(),

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -5,6 +5,7 @@ use if_addrs::Ifv4Addr;
 use std::{
     collections::{HashMap, HashSet},
     convert::TryInto,
+    fmt,
     net::Ipv4Addr,
     str::FromStr,
 };
@@ -411,6 +412,14 @@ impl TxtProperties {
     }
 }
 
+impl fmt::Display for TxtProperties {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let delimiter = ", ";
+        let props: Vec<String> = self.properties.iter().map(|p| p.to_string()).collect();
+        write!(f, "({})", props.join(delimiter))
+    }
+}
+
 /// Represents a property in a TXT record.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TxtProperty {
@@ -479,6 +488,12 @@ impl From<&str> for TxtProperty {
             key: key.to_string(),
             val: None,
         }
+    }
+}
+
+impl fmt::Display for TxtProperty {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}={}", self.key, self.val_str())
     }
 }
 


### PR DESCRIPTION
Since we started to use `Vec<u8>` in `TxtProperty.val`, the `Debug` output for `TxtProperty` no longer prints its string representation (It prints the hex values now). It is helpful to `impl fmt::Display` for `TxtProperty` and `TxtProperties` so we can use them in logging, etc.

The output looks like this: (using `examples/query.rs`)
```
$ cargo run --example query _printer._tcp 
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/examples/query _printer._tcp`
At 152.627µs : Received other event: SearchStarted("_printer._tcp.local. on addrs [192.168.0.113]")
At 382.937853ms : Received other event: ServiceFound("_printer._tcp.local.", "Brother HL-L2390DW._printer._tcp.local.")
At 1.010971528s : Received other event: SearchStarted("_printer._tcp.local. on addrs [192.168.0.113]")
At 1.406894418s: Resolved a new service: Brother HL-L2390DW._printer._tcp.local. IP: {192.168.0.111} 
TXT properties: (txtvers=1, qtotal=1, pdl=application/octet-stream,image/urf,image/pwg-raster, rp=duerqxesz5090, note=, ty=Brother HL-L2390DW, product=(Brother HL-L2390DW), adminurl=http://BRW485F99726515.local./, priority=50, usb_MFG=Brother, usb_MDL=HL-L2390DW, usb_CMD=PJL,HBP,URF, Color=F, Copies=T, Duplex=T, Fax=F, Scan=T, PaperCustom=T, Binary=T, Transparent=T, TBCP=F, UUID=e3248000-80ce-11db-8000-485f99726515)
```
