### PR TITLE
improve Debug output of TxtProperty

### DIFF
--- a/examples/query.rs
+++ b/examples/query.rs
@@ -37,7 +37,7 @@ fn main() {
         match event {
             ServiceEvent::ServiceResolved(info) => {
                 println!(
-                    "At {:?}: Resolved a new service: {} IP: {:?} TXT properties: {}",
+                    "At {:?}: Resolved a new service: {} IP: {:?} TXT properties: {:?}",
                     now.elapsed(),
                     info.get_fullname(),
                     info.get_addresses(),

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -775,6 +775,7 @@ mod tests {
 
     #[test]
     fn test_txt_property_debug() {
+        // Test UTF-8 property value.
         let prop_1 = TxtProperty {
             key: "key1".to_string(),
             val: Some("val1".to_string().into()),
@@ -785,6 +786,7 @@ mod tests {
             "TxtProperty {key: \"key1\", val: Some(\"val1\")}"
         );
 
+        // Test non-UTF-8 property value.
         let prop_2 = TxtProperty {
             key: "key2".to_string(),
             val: Some(vec![150u8, 151u8, 152u8]),


### PR DESCRIPTION
The default `Debug` output for `TxtProperty` prints ike this: 
```
TxtProperty { key: "ipv4", val: Some([49, 50, 55, 46, 48, 46, 48, 46, 49]) }
```
We provide custom `Debug` implementation so we can have a more readable output for `self.val`: 
- If it has some UTF-8 string, we will just print a quoted string.
- If it is not UTF-8, we will print its bytes in hex, without `,` separating each byte.
like this: 
```
TxtProperty {key: "ipv4", val: Some("127.0.0.1")}
```
