### PR TITLE
Refactoring DnsCache and how to resolve Service Instance

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -803,6 +803,8 @@ pub(crate) struct DnsIncoming {
     offset: usize,
     data: Vec<u8>,
     pub(crate) questions: Vec<DnsQuestion>,
+    /// This field includes records in the `answers` section
+    /// and in the `additionals` section.
     pub(crate) answers: Vec<DnsRecordBox>,
     pub(crate) id: u16,
     flags: u16,

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -73,6 +73,9 @@ pub(crate) struct DnsRecord {
     pub(crate) entry: DnsEntry,
     ttl: u32,     // in seconds, 0 means this record should not be cached
     created: u64, // UNIX time in millis
+
+    /// Support re-query an instance before its PTR record expires.
+    /// See https://datatracker.ietf.org/doc/html/rfc6762#section-5.2
     refresh: u64, // UNIX time in millis
 }
 
@@ -86,6 +89,10 @@ impl DnsRecord {
             created,
             refresh,
         }
+    }
+
+    pub(crate) fn get_created(&self) -> u64 {
+        self.created
     }
 
     pub(crate) fn is_expired(&self, now: u64) -> bool {

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1176,7 +1176,7 @@ impl Zeroconf {
 
         /// Represents a DNS record change that involves one service instance.
         struct InstanceChange {
-            ty: u16, // The type of DNS record for the instance.
+            ty: u16,      // The type of DNS record for the instance.
             name: String, // The name of the record.
         }
 

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "logging")]
 use crate::log::error;
-use crate::{dns_parser::current_time_millis, Error, Result};
+use crate::{Error, Result};
 use if_addrs::Ifv4Addr;
 use std::{
     collections::{HashMap, HashSet},
@@ -31,8 +31,7 @@ pub struct ServiceInfo {
     priority: u16,
     weight: u16,
     txt_properties: TxtProperties,
-    last_update: u64, // UNIX time in millis
-    addr_auto: bool,  // Let the system update addresses automatically.
+    addr_auto: bool, // Let the system update addresses automatically.
 }
 
 impl ServiceInfo {
@@ -74,7 +73,6 @@ impl ServiceInfo {
         let server = host_name.to_string();
         let addresses = host_ipv4.as_ipv4_addrs()?;
         let txt_properties = properties.into_txt_properties();
-        let last_update = current_time_millis();
 
         // RFC6763 section 6.4: https://www.rfc-editor.org/rfc/rfc6763#section-6.4
         // The characters of a key MUST be printable US-ASCII values (0x20-0x7E)
@@ -107,7 +105,6 @@ impl ServiceInfo {
             priority: 0,
             weight: 0,
             txt_properties,
-            last_update,
             addr_auto: false,
         };
 
@@ -275,14 +272,6 @@ impl ServiceInfo {
         } else {
             false
         }
-    }
-
-    pub(crate) fn get_last_update(&self) -> u64 {
-        self.last_update
-    }
-
-    pub(crate) fn set_last_update(&mut self, update: u64) {
-        self.last_update = update;
     }
 }
 


### PR DESCRIPTION
Simplify the logic of resolving an instance: always resolve from the cache. For any incoming updates, we update the cache first, then try to resolve according to the cache.

We're still not doing all the things for the cache updates as mentioned in RFCs, but I think with the changes, the future enhancements will be easier.

- Got rid of `instances_found` and the related state. As they are essentially another kind of cache but it is error-prone to keep them up-to-date and consistent with `DnsCache`. 
- All instances info are generated on-demand now, from the one and only cache.

