### PR TITLE
Returns an error with logging for read_name invalid offset

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -1002,6 +1002,14 @@ impl DnsIncoming {
         let mut at_end = false;
 
         loop {
+            if offset >= data.len() {
+                return Err(Error::Msg(format!(
+                    "read_name: offset: {} data len {}. DnsIncoming: {:?}",
+                    offset,
+                    data.len(),
+                    self
+                )));
+            }
             let length = data[offset];
             if length == 0 {
                 if !at_end {


### PR DESCRIPTION
This is to help debugging / fixing a crash found in issue #105 .