### PR TITLE
register example should keep running

### DIFF
--- a/examples/query.rs
+++ b/examples/query.rs
@@ -22,8 +22,7 @@ fn main() {
     let mut service_type = match std::env::args().nth(1) {
         Some(arg) => arg,
         None => {
-            println!("ERROR: require a service_type as argument. For example: ");
-            println!("cargo run --example query _my-service._udp");
+            print_usage();
             return;
         }
     };
@@ -55,4 +54,13 @@ fn main() {
             }
         }
     }
+}
+
+fn print_usage() {
+    println!("Usage: cargo run --example query <service_type_without_domain_postfix>");
+    println!("Example: ");
+    println!("cargo run --example query _my-service._udp");
+    println!("");
+    println!("You can also do a meta-query per RFC 6763 to find which services are available:");
+    println!("cargo run --example query _services._dns-sd._udp");
 }

--- a/examples/register.rs
+++ b/examples/register.rs
@@ -72,11 +72,6 @@ fn main() {
 
     println!("Registered service {}.{}", &instance_name, &service_type);
 
-    // Only do this if we monitor the daemon events, which is optional.
-    if let Ok(event) = monitor.recv() {
-        println!("Daemon event: {:?}", &event);
-    }
-
     if should_unreg {
         let wait_in_secs = 2;
         println!("Sleeping {} seconds before unregister", wait_in_secs);
@@ -85,6 +80,11 @@ fn main() {
         let receiver = mdns.unregister(&service_fullname).unwrap();
         while let Ok(event) = receiver.recv() {
             println!("unregister result: {:?}", &event);
+        }
+    } else {
+        // Monitor the daemon events.
+        while let Ok(event) = monitor.recv() {
+            println!("Daemon event: {:?}", &event);
         }
     }
 }


### PR DESCRIPTION
The `register` example was broken in a recent [commit](https://github.com/keepsimple1/mdns-sd/commit/3d61f2d720ddf98ac1e6bc9a8392caa62803b1f9) so that by default it is no longer keeping running, i.e. exits immediately. This is a problem as it cannot be used for a client/server testing.

Also added more usage prints for the `query` example.