### PR TITLE
Enable logging for the examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ socket2 = { version = "0.4", features = ["all"] }      # socket APIs
 
 [dev-dependencies]
 fastrand = "1.8"
+env_logger = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ socket2 = { version = "0.4", features = ["all"] }      # socket APIs
 
 [dev-dependencies]
 fastrand = "1.8"
-env_logger = "0.10"
+env_logger = "0.9"

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -16,6 +16,8 @@
 use mdns_sd::{ServiceDaemon, ServiceEvent};
 
 fn main() {
+    env_logger::init();
+
     // Create a daemon
     let mdns = ServiceDaemon::new().expect("Failed to create daemon");
 
@@ -47,7 +49,7 @@ fn main() {
             }
             other_event => {
                 println!(
-                    "At {:?} : Received other event: {:?}",
+                    "At {:?} : {:?}",
                     now.elapsed(),
                     &other_event
                 );

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -48,11 +48,7 @@ fn main() {
                 );
             }
             other_event => {
-                println!(
-                    "At {:?} : {:?}",
-                    now.elapsed(),
-                    &other_event
-                );
+                println!("At {:?} : {:?}", now.elapsed(), &other_event);
             }
         }
     }

--- a/examples/register.rs
+++ b/examples/register.rs
@@ -15,6 +15,10 @@ use mdns_sd::{ServiceDaemon, ServiceInfo};
 use std::{env, thread, time::Duration};
 
 fn main() {
+    // Please use env vars to change the logging level.
+    // For example: `RUST_LOG=debug <program>`.
+    env_logger::init();
+
     // Simple command line options.
     let args: Vec<String> = env::args().collect();
     let mut should_unreg = false;


### PR DESCRIPTION
Triggered by issue #106. The idea is to make the examples more useful in debugging issues. 

For example: `$ RUST_LOG=debug cargo r --example query _printer._tcp`