### PR TITLE
feat(ServiceDaemon): possibility to use a specific network interface

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.60.0
+          toolchain: 1.61.0
           override: true
           components: rustfmt, clippy
       - name: Run rustfmt and fail if any warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mdns-sd"
 version = "0.7.4"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 authors = ["keepsimple <keepsimple@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "mdns-sd"
 version = "0.7.4"
+rust-version = "1.60.0"
 authors = ["keepsimple <keepsimple@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Currently this library has the following limitations:
 
 ## Minimum Rust version
 
-Tested against Rust 1.60.0
+Tested against Rust 1.61.0
 
 ## License
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1710,7 +1710,7 @@ fn my_ipv4_interfaces(interface: Option<&str>) -> Vec<Ifv4Addr> {
     let mut intf_vec: Vec<Ifv4Addr> = if_addrs::get_if_addrs()
         .unwrap_or_default()
         .into_iter()
-        .filter(|i| interface.is_none() || interface.is_some_and(|f| i.name == f))
+        .filter(|i| interface.is_none() || (interface.is_some() && interface.unwrap() == i.name))
         .filter_map(|i| {
             if i.is_loopback() {
                 None


### PR DESCRIPTION
## Add the possibility of using a specific network interface using the on_interface constructor function.
### The addition is not a breaking change.

Hello, for my use case I need to use a specific network interface (that is also using a link local address) so I added this feature to your fantastic library.

If you think this could be useful (I do 😁) consider merging this PR or let me know if you want me to change something before merging.