### PR TITLE
revert the commit ff659a4: support link-local interfaces

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.60.0
+          toolchain: 1.61.0
           override: true
           components: rustfmt, clippy
       - name: Run rustfmt and fail if any warnings

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Currently this library has the following limitations:
 
 ## Minimum Rust version
 
-Tested against Rust 1.60.0
+Tested against Rust 1.61.0
 
 ## License
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1671,37 +1671,22 @@ fn call_listener(
 }
 
 /// Returns valid IPv4 interfaces in the host system.
+/// Loopback interfaces are excluded.
 fn my_ipv4_interfaces() -> Vec<Ifv4Addr> {
-    // Link local interfaces have the 169.254/16 prefix,
-    // see RFC 3927 for details.
-    let mut link_local_count = 0;
-
-    let mut intf_vec: Vec<Ifv4Addr> = if_addrs::get_if_addrs()
+    if_addrs::get_if_addrs()
         .unwrap_or_default()
         .into_iter()
         .filter_map(|i| {
             if i.is_loopback() {
                 None
             } else {
-                if i.is_link_local() {
-                    link_local_count += 1;
-                }
                 match i.addr {
                     IfAddr::V4(ifv4) => Some(ifv4),
                     _ => None,
                 }
             }
         })
-        .collect();
-
-    // If we have both routable interfaces and link-local interfaces,
-    // we only keep the routable interfaces. Otherwise, it can confuse
-    // the clients.
-    if link_local_count > 0 && intf_vec.len() > link_local_count {
-        intf_vec.retain(|i| !i.is_link_local())
-    }
-
-    intf_vec
+        .collect()
 }
 
 /// Sends out `packet` to `addr` on the socket in `intf_sock`.

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -632,22 +632,16 @@ fn instance_name_two_dots() {
 }
 
 fn my_ipv4_interfaces() -> Vec<Ifv4Addr> {
-    let mut link_local_count = 0;
-
     // Use a random port for binding test.
     let test_port = fastrand::u16(8000u16..9000u16);
 
-    let mut intf_vec: Vec<Ifv4Addr> = if_addrs::get_if_addrs()
+    if_addrs::get_if_addrs()
         .unwrap_or_default()
         .into_iter()
         .filter_map(|i| {
             if i.is_loopback() {
                 None
             } else {
-                if i.is_link_local() {
-                    link_local_count += 1;
-                }
-
                 match i.addr {
                     IfAddr::V4(ifv4) =>
                     // Use a 'bind' to check if this is a valid IPv4 addr.
@@ -664,13 +658,7 @@ fn my_ipv4_interfaces() -> Vec<Ifv4Addr> {
                 }
             }
         })
-        .collect();
-
-    if link_local_count > 0 && intf_vec.len() > link_local_count {
-        intf_vec.retain(|i| !i.is_link_local())
-    }
-
-    intf_vec
+        .collect()
 }
 
 /// Returns a made-up IPv4 address "net.1.1.1", where


### PR DESCRIPTION
See issue #121 .  It turns out sometimes clients want to use link-local interfaces alongside with routable interfaces. The original problem addressed by #117 should be handled on the client side, e.g. filtering out link-local interfaces by the client itself, not by the mdns-sd library.