### PR TITLE
use local UDP socket to signal the daemon

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,10 @@
 //!         }
 //!     }
 //! });
+//!
+//! // Gracefully shutdown the daemon.
+//! std::thread::sleep(std::time::Duration::from_secs(1));
+//! mdns.shutdown().unwrap();
 //! ```
 //!
 //! ## Example: a server publishs a service and responds to queries.
@@ -86,6 +90,10 @@
 //!
 //! // Register with the daemon, which publishes the service.
 //! mdns.register(my_service).expect("Failed to register our service");
+//!
+//! // Gracefully shutdown the daemon
+//! std::thread::sleep(std::time::Duration::from_secs(1));
+//! mdns.shutdown().unwrap();
 //! ```
 //!
 //! # Limitations


### PR DESCRIPTION
This is to address issue #124 . The idea has two-folds:

1. For client side commands sent into the flume channel, we use a socket to trigger an event. (Unfortunately `flume` channel itself does not implement `AsRawFd` trait and does not support `polling` event together with existing mDNS UDP sockets.

2. For other timing based tasks, we store a simple `u64` time for triggering them and uses timeouts to wait on them together with the sockets.

After this change, everything in the daemon run loop will be event driven (i.e. reactive) and have reduced latency.