### PR TITLE
Added the link-local feature to if_addrs in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default = ["async", "logging"]
 
 [dependencies]
 flume = { version = "0.10", default-features = false } # channel between threads
-if-addrs = "0.10"                                      # get local IP addresses
+if-addrs = { version = "0.10", features = ["link-local"] } # get local IP addresses
 log = { version = "0.4", optional = true }             # logging
 polling = "2.1"                                        # select/poll sockets
 socket2 = { version = "0.4", features = ["all"] }      # socket APIs


### PR DESCRIPTION
`if_addrs` disables link-local addresses on windows if the `"link-local"` feature is not enabled. See:
https://github.com/messense/if-addrs/blob/947c6342681b047b48b5f53eb75049881d2dfa20/src/sockaddr.rs#L63C21-L63C21

Currently, the behaviour on Linux is to allow link-local IPv4 addresses, but IPv6 and windows is behind the feature gate.

This PR trivially adds the `link-local` feature to the `if-addrs` package.

It might be desirable to reflect the feature gating of link-local addresses instead of accepting this PR as-is.