### PR TITLE
Ipv6

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -7,8 +7,8 @@
 #[cfg(feature = "logging")]
 use crate::log::{debug, error};
 use crate::{Error, Result, ServiceInfo};
-use if_addrs::Ifv4Addr;
-use std::{any::Any, cmp, collections::HashMap, fmt, net::Ipv4Addr, str, time::SystemTime};
+use if_addrs::Interface;
+use std::{any::Any, cmp, collections::HashMap, fmt, net::{IpAddr, Ipv4Addr, Ipv6Addr}, str, time::SystemTime, convert::TryInto};
 
 pub(crate) const TYPE_A: u16 = 1; // IPv4 address
 pub(crate) const TYPE_CNAME: u16 = 5;
@@ -179,11 +179,11 @@ pub(crate) trait DnsRecordExt: fmt::Debug {
 #[derive(Debug)]
 pub(crate) struct DnsAddress {
     pub(crate) record: DnsRecord,
-    pub(crate) address: Ipv4Addr,
+    pub(crate) address: IpAddr,
 }
 
 impl DnsAddress {
-    pub(crate) fn new(name: &str, ty: u16, class: u16, ttl: u32, address: Ipv4Addr) -> Self {
+    pub(crate) fn new(name: &str, ty: u16, class: u16, ttl: u32, address: IpAddr) -> Self {
         let record = DnsRecord::new(name, ty, class, ttl);
         Self { record, address }
     }
@@ -695,7 +695,7 @@ impl DnsOutgoing {
         &mut self,
         msg: &DnsIncoming,
         service: &ServiceInfo,
-        intf: &Ifv4Addr,
+        intf: &Interface,
     ) {
         let intf_addrs = service.get_addrs_on_intf(intf);
         if intf_addrs.is_empty() {

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -8,7 +8,16 @@
 use crate::log::{debug, error};
 use crate::{Error, Result, ServiceInfo};
 use if_addrs::Interface;
-use std::{any::Any, cmp, collections::HashMap, fmt, net::{IpAddr, Ipv4Addr, Ipv6Addr}, str, time::SystemTime, convert::TryInto};
+use std::{
+    any::Any,
+    cmp,
+    collections::HashMap,
+    convert::TryInto,
+    fmt,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    str,
+    time::SystemTime,
+};
 
 pub(crate) const TYPE_A: u16 = 1; // IPv4 address
 pub(crate) const TYPE_CNAME: u16 = 5;
@@ -1041,13 +1050,17 @@ impl DnsIncoming {
     }
 
     fn read_ipv4(&mut self) -> Ipv4Addr {
-        let bytes: [u8; 4] = (&self.data)[self.offset..self.offset + 4].try_into().unwrap();
+        let bytes: [u8; 4] = (&self.data)[self.offset..self.offset + 4]
+            .try_into()
+            .unwrap();
         self.offset += bytes.len();
         Ipv4Addr::from(bytes)
     }
 
     fn read_ipv6(&mut self) -> Ipv6Addr {
-        let bytes: [u8; 16] = (&self.data)[self.offset..self.offset + 16].try_into().unwrap();
+        let bytes: [u8; 16] = (&self.data)[self.offset..self.offset + 16]
+            .try_into()
+            .unwrap();
         self.offset += bytes.len();
         Ipv6Addr::from(bytes)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
 //! // Create a service info.
 //! let service_type = "_mdns-sd-my-test._udp.local.";
 //! let instance_name = "my_instance";
-//! let host_ipv4 = "192.168.1.12";
+//! let ip = "192.168.1.12";
 //! let host_name = "192.168.1.12.local.";
 //! let port = 5200;
 //! let properties = [("property_1", "test"), ("property_2", "1234")];
@@ -83,7 +83,7 @@
 //!     service_type,
 //!     instance_name,
 //!     host_name,
-//!     host_ipv4,
+//!     ip,
 //!     port,
 //!     &properties[..],
 //! ).unwrap();
@@ -104,7 +104,6 @@
 //! - DNS:    [RFC 1035](https://tools.ietf.org/html/rfc1035)
 //!
 //! We focus on the common use cases at first, and currently have the following limitations:
-//! - Only support IPv4, not IPv6.
 //! - Only support multicast, not unicast send/recv.
 //! - Only support 32-bit or bigger platforms, not 16-bit platforms.
 
@@ -135,7 +134,7 @@ pub use service_daemon::{
     DaemonEvent, Metrics, ServiceDaemon, ServiceEvent, UnregisterStatus,
     SERVICE_NAME_LEN_MAX_DEFAULT,
 };
-pub use service_info::{AsIpv4Addrs, IntoTxtProperties, ServiceInfo, TxtProperties, TxtProperty};
+pub use service_info::{AsIpAddrs, IntoTxtProperties, ServiceInfo, TxtProperties, TxtProperty};
 
 /// A handler to receive messages from [ServiceDaemon]. Re-export from `flume` crate.
 pub use flume::Receiver;

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1879,10 +1879,7 @@ fn my_ip_interfaces() -> Vec<Interface> {
     if_addrs::get_if_addrs()
         .unwrap_or_default()
         .into_iter()
-        .filter_map(|i| match i.is_loopback() {
-            true => None,
-            false => Some(i),
-        })
+        .filter(|i| !i.is_loopback())
         .collect()
 }
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -836,7 +836,7 @@ impl Zeroconf {
     fn add_poll_impl(
         poll_ids: &mut HashMap<usize, IpAddr>,
         poll_id_count: &mut usize,
-        ip: IpAddr
+        ip: IpAddr,
     ) -> usize {
         let key = *poll_id_count;
         *poll_id_count += 1;

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -34,7 +34,8 @@ use crate::{
     dns_parser::{
         current_time_millis, DnsAddress, DnsIncoming, DnsOutgoing, DnsPointer, DnsRecordBox,
         DnsRecordExt, DnsSrv, DnsTxt, CLASS_IN, CLASS_UNIQUE, FLAGS_AA, FLAGS_QR_QUERY,
-        FLAGS_QR_RESPONSE, MAX_MSG_ABSOLUTE, TYPE_A, TYPE_AAAA, TYPE_ANY, TYPE_PTR, TYPE_SRV, TYPE_TXT,
+        FLAGS_QR_RESPONSE, MAX_MSG_ABSOLUTE, TYPE_A, TYPE_AAAA, TYPE_ANY, TYPE_PTR, TYPE_SRV,
+        TYPE_TXT,
     },
     error::{Error, Result},
     service_info::{split_sub_domain, ServiceInfo},
@@ -49,7 +50,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt,
     io::Read,
-    net::{Ipv4Addr, Ipv6Addr, IpAddr, SocketAddr, SocketAddrV4, SocketAddrV6, UdpSocket},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, UdpSocket},
     str, thread,
     time::Duration,
     vec,
@@ -606,9 +607,14 @@ fn new_socket_bind(intf: &Interface) -> Result<Socket> {
             sock.send_to(&test_packet, &multicast_addr)
                 .map_err(|e| e_fmt!("send multicast packet on addr {}: {}", ip, e))?;
             Ok(sock)
-        },
+        }
         IpAddr::V6(ip) => {
-            let mut addr = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0).into(), MDNS_PORT, 0, 0);
+            let mut addr = SocketAddrV6::new(
+                Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0).into(),
+                MDNS_PORT,
+                0,
+                0,
+            );
             addr.set_scope_id(intf.index.unwrap_or(0));
             let sock = new_socket(addr.into(), true)?;
 
@@ -626,9 +632,8 @@ fn new_socket_bind(intf: &Interface) -> Result<Socket> {
             sock.send_to(&test_packet, &multicast_addr)
                 .map_err(|e| e_fmt!("send multicast packet on addr {}: {}", ip, e))?;
             Ok(sock)
-        },
+        }
     }
-
 }
 
 /// Creates a new UDP socket to bind to `port` with REUSEPORT option.
@@ -826,8 +831,7 @@ impl Zeroconf {
         }
 
         // Keep the interfaces only if they still exist.
-        self.intf_socks
-            .retain(|_, v| my_ifaddrs.contains(&v.intf));
+        self.intf_socks.retain(|_, v| my_ifaddrs.contains(&v.intf));
 
         // Add newly found interfaces.
         for intf in my_ifaddrs {
@@ -1426,7 +1430,7 @@ impl Zeroconf {
                     for service in self.my_services.values() {
                         if service.get_hostname() == question.entry.name.to_lowercase() {
                             let intf_addrs = service.get_addrs_on_intf(&intf_sock.intf);
-                            if intf_addrs.is_empty() && (qtype == TYPE_A || qtype == TYPE_AAAA){
+                            if intf_addrs.is_empty() && (qtype == TYPE_A || qtype == TYPE_AAAA) {
                                 let t = match qtype {
                                     TYPE_A => "TYPE_A",
                                     TYPE_AAAA => "TYPE_AAAA",
@@ -1854,11 +1858,9 @@ fn my_ip_interfaces() -> Vec<Interface> {
     if_addrs::get_if_addrs()
         .unwrap_or_default()
         .into_iter()
-        .filter_map(|i| {
-            match i.is_loopback() {
-                true => None,
-                false => Some(i),
-            }
+        .filter_map(|i| match i.is_loopback() {
+            true => None,
+            false => Some(i),
         })
         .collect()
 }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -72,7 +72,6 @@ const MDNS_PORT: u16 = 5353;
 const GROUP_ADDR_V4: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 251);
 const GROUP_ADDR_V6: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0xfb);
 const LOOPBACK_V4: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
-const LOOPBACK_V6: Ipv6Addr = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
 
 /// Response status code for the service `unregister` call.
 #[derive(Debug)]
@@ -138,21 +137,8 @@ impl ServiceDaemon {
     pub fn new() -> Result<Self> {
         // Use port 0 to allow the system assign a random available port,
         // no need for a pre-defined port number.
-        Self::new_with_signal_addr(SocketAddrV4::new(LOOPBACK_V4, 0).into())
-    }
+        let signal_addr = SocketAddrV4::new(LOOPBACK_V4, 0);
 
-    /// Creates a new daemon and spawns a thread to run the daemon.
-    ///
-    /// The daemon (re)uses the default mDNS port 5353. To keep it simple, we don't
-    /// ask callers to set the port.
-    /// This one uses an ipv6 local address for the signal mechanism.
-    pub fn new_signal_v6() -> Result<Self> {
-        // Use port 0 to allow the system assign a random available port,
-        // no need for a pre-defined port number.
-        Self::new_with_signal_addr(SocketAddrV6::new(LOOPBACK_V6, 0, 0, 0).into())
-    }
-
-    fn new_with_signal_addr(signal_addr: SocketAddr) -> Result<Self> {
         let signal_sock = UdpSocket::bind(signal_addr)
             .map_err(|e| e_fmt!("failed to create signal_sock for daemon: {}", e))?;
 
@@ -193,10 +179,7 @@ impl ServiceDaemon {
         })?;
 
         // Second, send a signal to notify the daemon.
-        let addr: SocketAddr = match self.signal_addr {
-            SocketAddr::V4(_) => SocketAddrV4::new(LOOPBACK_V4, 0).into(),
-            SocketAddr::V6(_) => SocketAddrV6::new(LOOPBACK_V6, 0, 0, 0).into(),
-        };
+        let addr = SocketAddrV4::new(LOOPBACK_V4, 0);
         let socket = UdpSocket::bind(addr)
             .map_err(|e| e_fmt!("Failed to create socket to send signal: {}", e))?;
         socket

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -642,16 +642,15 @@ fn new_socket_bind(intf: &Interface) -> Result<Socket> {
             Ok(sock)
         }
         IpAddr::V6(ip) => {
-            let mut addr =
+            let addr =
                 SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0), MDNS_PORT, 0, 0);
-            addr.set_scope_id(intf.index.unwrap_or(0));
             let sock = new_socket(addr.into(), true)?;
 
             // Join mDNS group to receive packets.
             sock.join_multicast_v6(&GROUP_ADDR_V6, intf.index.unwrap_or(0))
                 .map_err(|e| e_fmt!("join multicast group on addr {}: {}", ip, e))?;
 
-            // Set IP6_MULTICAST_IF to send packets.
+            // Set IPV6_MULTICAST_IF to send packets.
             sock.set_multicast_if_v6(intf.index.unwrap_or(0))
                 .map_err(|e| e_fmt!("set multicast_if on addr {}: {}", ip, e))?;
 
@@ -1905,7 +1904,7 @@ fn broadcast_on_intf<'a>(packet: &'a [u8], intf: &IntfSock) -> &'a [u8] {
         if_addrs::IfAddr::V4(_) => SocketAddrV4::new(GROUP_ADDR_V4, MDNS_PORT).into(),
         if_addrs::IfAddr::V6(_) => {
             let mut sock = SocketAddrV6::new(GROUP_ADDR_V6, MDNS_PORT, 0, 0);
-            sock.set_scope_id(intf.intf.index.unwrap_or(0));
+            sock.set_scope_id(intf.intf.index.unwrap_or(0)); // Choose iface for multicast
             sock.into()
         }
     };

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -157,7 +157,8 @@ impl ServiceDaemon {
             .map_err(|e| e_fmt!("failed to create signal_sock for daemon: {}", e))?;
 
         // Get the socket with the OS chosen port
-        let signal_addr = signal_sock.local_addr()
+        let signal_addr = signal_sock
+            .local_addr()
             .map_err(|e| e_fmt!("failed to get signal sock addr: {}", e))?;
 
         // Must be nonblocking so we can listen to it together with mDNS sockets.
@@ -200,7 +201,14 @@ impl ServiceDaemon {
             .map_err(|e| e_fmt!("Failed to create socket to send signal: {}", e))?;
         socket
             .send_to(cmd_name.as_bytes(), self.signal_addr)
-            .map_err(|e| e_fmt!("signal socket send_to {} ({}) failed: {}", self.signal_addr, cmd_name, e))?;
+            .map_err(|e| {
+                e_fmt!(
+                    "signal socket send_to {} ({}) failed: {}",
+                    self.signal_addr,
+                    cmd_name,
+                    e
+                )
+            })?;
 
         Ok(())
     }
@@ -825,7 +833,11 @@ impl Zeroconf {
 
     /// Insert a new IP into the poll map and return key
     /// This exist to satisfy the borrow checker
-    fn add_poll_impl(poll_ids: &mut HashMap<usize, IpAddr>, poll_id_count: &mut usize, ip: IpAddr) -> usize {
+    fn add_poll_impl(
+        poll_ids: &mut HashMap<usize, IpAddr>,
+        poll_id_count: &mut usize,
+        ip: IpAddr
+    ) -> usize {
         let key = *poll_id_count;
         *poll_id_count += 1;
         let _ = (*poll_ids).insert(key, ip);

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -642,8 +642,7 @@ fn new_socket_bind(intf: &Interface) -> Result<Socket> {
             Ok(sock)
         }
         IpAddr::V6(ip) => {
-            let addr =
-                SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0), MDNS_PORT, 0, 0);
+            let addr = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0), MDNS_PORT, 0, 0);
             let sock = new_socket(addr.into(), true)?;
 
             // Join mDNS group to receive packets.

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -1,12 +1,12 @@
 #[cfg(feature = "logging")]
 use crate::log::error;
 use crate::{Error, Result};
-use if_addrs::Ifv4Addr;
+use if_addrs::{Interface, IfAddr};
 use std::{
     collections::{HashMap, HashSet},
     convert::TryInto,
     fmt,
-    net::Ipv4Addr,
+    net::IpAddr,
     str::FromStr,
 };
 
@@ -24,7 +24,7 @@ pub struct ServiceInfo {
     sub_domain: Option<String>, // <subservice>._sub.<service>.<domain>
     fullname: String,           // <instance>.<service>.<domain>
     server: String,             // fully qualified name for service host
-    addresses: HashSet<Ipv4Addr>,
+    addresses: HashSet<IpAddr>,
     port: u16,
     host_ttl: u32,  // used for SRV and Address records
     other_ttl: u32, // used for PTR and TXT records
@@ -48,20 +48,24 @@ impl ServiceInfo {
     /// - `Option<HashMap<String, String>>`
     /// - slice of tuple: `&[(K, V)]` where `K` and `V` are [`std::string::ToString`].
     ///
-    /// `host_ipv4` can be one or more IPv4 addresses, in a type that implements
-    /// [`AsIpv4Addrs`] trait. It supports:
+    /// `ip` can be one or more IP addresses, in a type that implements
+    /// [`AsIpAddrs`] trait. It supports:
     ///
     /// - Single IPv4: `"192.168.0.1"`
+    /// - Single IPv6: `"2001:0db8::7334"`
     /// - Multiple IPv4 separated by comma: `"192.168.0.1,192.168.0.2"`
+    /// - Multiple IPv6 separated by comma: `"2001:0db8::7334,2001:0db8::7335"`
     /// - A slice of IPv4: `&["192.168.0.1", "192.168.0.2"]`
-    /// - All the above formats with [Ipv4Addr] or `String` instead of `&str`.
+    /// - A slice of IPv6: `&["2001:0db8::7334", "2001:0db8::7335"]`
+    /// - A mix of IPv4 and IPv6: `"192.168.0.1,2001:0db8::7334"`
+    /// - All the above formats with [IpAddr] or `String` instead of `&str`.
     ///
     /// The host TTL and other TTL are set to default values.
-    pub fn new<Ip: AsIpv4Addrs, P: IntoTxtProperties>(
+    pub fn new<Ip: AsIpAddrs, P: IntoTxtProperties>(
         ty_domain: &str,
         my_name: &str,
         host_name: &str,
-        host_ipv4: Ip,
+        ip: Ip,
         port: u16,
         properties: P,
     ) -> Result<Self> {
@@ -71,7 +75,7 @@ impl ServiceInfo {
         let ty_domain = ty_domain.to_string();
         let sub_domain = sub_domain.map(str::to_string);
         let server = host_name.to_string();
-        let addresses = host_ipv4.as_ipv4_addrs()?;
+        let addresses = ip.as_ip_addrs()?;
         let txt_properties = properties.into_txt_properties();
 
         // RFC6763 section 6.4: https://www.rfc-editor.org/rfc/rfc6763#section-6.4
@@ -112,7 +116,7 @@ impl ServiceInfo {
     }
 
     /// Indicates that the library should automatically
-    /// update the addresses of this service, when IPv4
+    /// update the addresses of this service, when IP
     /// address(es) are added or removed on the host.
     pub fn enable_addr_auto(mut self) -> Self {
         self.addr_auto = true;
@@ -120,7 +124,7 @@ impl ServiceInfo {
     }
 
     /// Returns if the service's addresses will be updated
-    /// automatically when the host IPv4 addrs change.
+    /// automatically when the host IP addrs change.
     pub fn is_addr_auto(&self) -> bool {
         self.addr_auto
     }
@@ -194,7 +198,7 @@ impl ServiceInfo {
 
     /// Returns the service's addresses
     #[inline]
-    pub fn get_addresses(&self) -> &HashSet<Ipv4Addr> {
+    pub fn get_addresses(&self) -> &HashSet<IpAddr> {
         &self.addresses
     }
 
@@ -224,10 +228,10 @@ impl ServiceInfo {
 
     /// Returns a list of addresses that are in the same LAN as
     /// the interface `intf`.
-    pub(crate) fn get_addrs_on_intf(&self, intf: &Ifv4Addr) -> Vec<Ipv4Addr> {
+    pub(crate) fn get_addrs_on_intf(&self, intf: &Interface) -> Vec<IpAddr> {
         self.addresses
             .iter()
-            .filter(|a| valid_ipv4_on_intf(a, intf))
+            .filter(|a| valid_ip_on_intf(a, intf))
             .copied()
             .collect()
     }
@@ -243,11 +247,11 @@ impl ServiceInfo {
     }
 
     /// Insert `addr` into service info addresses.
-    pub(crate) fn insert_ipv4addr(&mut self, addr: Ipv4Addr) {
+    pub(crate) fn insert_ipaddr(&mut self, addr: IpAddr) {
         self.addresses.insert(addr);
     }
 
-    pub(crate) fn remove_ipv4addr(&mut self, addr: &Ipv4Addr) {
+    pub(crate) fn remove_ipaddr(&mut self, addr: &IpAddr) {
         self.addresses.remove(addr);
     }
 
@@ -276,13 +280,13 @@ impl ServiceInfo {
 }
 
 /// This trait allows for parsing an input into a set of one or multiple [`Ipv4Addr`].
-pub trait AsIpv4Addrs {
-    fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>>;
+pub trait AsIpAddrs {
+    fn as_ip_addrs(&self) -> Result<HashSet<IpAddr>>;
 }
 
-impl<T: AsIpv4Addrs> AsIpv4Addrs for &T {
-    fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>> {
-        (*self).as_ipv4_addrs()
+impl<T: AsIpAddrs> AsIpAddrs for &T {
+    fn as_ip_addrs(&self) -> Result<HashSet<IpAddr>> {
+        (*self).as_ip_addrs()
     }
 }
 
@@ -290,12 +294,12 @@ impl<T: AsIpv4Addrs> AsIpv4Addrs for &T {
 /// For example: "127.0.0.1,127.0.0.2".
 ///
 /// If the string is empty, will return an empty set.
-impl AsIpv4Addrs for &str {
-    fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>> {
+impl AsIpAddrs for &str {
+    fn as_ip_addrs(&self) -> Result<HashSet<IpAddr>> {
         let mut addrs = HashSet::new();
 
         if !self.is_empty() {
-            let iter = self.split(',').map(str::trim).map(Ipv4Addr::from_str);
+            let iter = self.split(',').map(str::trim).map(IpAddr::from_str);
             for addr in iter {
                 let addr = addr.map_err(|err| Error::ParseIpAddr(err.to_string()))?;
                 addrs.insert(addr);
@@ -306,18 +310,18 @@ impl AsIpv4Addrs for &str {
     }
 }
 
-impl AsIpv4Addrs for String {
-    fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>> {
-        self.as_str().as_ipv4_addrs()
+impl AsIpAddrs for String {
+    fn as_ip_addrs(&self) -> Result<HashSet<IpAddr>> {
+        self.as_str().as_ip_addrs()
     }
 }
 
 /// Support slice. Example: &["127.0.0.1", "127.0.0.2"]
-impl<I: AsIpv4Addrs> AsIpv4Addrs for &[I] {
-    fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>> {
+impl<I: AsIpAddrs> AsIpAddrs for &[I] {
+    fn as_ip_addrs(&self) -> Result<HashSet<IpAddr>> {
         let mut addrs = HashSet::new();
 
-        for result in self.iter().map(I::as_ipv4_addrs) {
+        for result in self.iter().map(I::as_ip_addrs) {
             addrs.extend(result?);
         }
 
@@ -327,14 +331,14 @@ impl<I: AsIpv4Addrs> AsIpv4Addrs for &[I] {
 
 /// Optimization for zero sized/empty values, as `()` will never take up any space or evaluate to
 /// anything, helpful in contexts where we just want an empty value.
-impl AsIpv4Addrs for () {
-    fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>> {
+impl AsIpAddrs for () {
+    fn as_ip_addrs(&self) -> Result<HashSet<IpAddr>> {
         Ok(HashSet::new())
     }
 }
 
-impl AsIpv4Addrs for std::net::Ipv4Addr {
-    fn as_ipv4_addrs(&self) -> Result<HashSet<Ipv4Addr>> {
+impl AsIpAddrs for std::net::IpAddr {
+    fn as_ip_addrs(&self) -> Result<HashSet<IpAddr>> {
         let mut ips = HashSet::new();
         ips.insert(*self);
 

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -664,11 +664,22 @@ pub(crate) fn split_sub_domain(domain: &str) -> (&str, Option<&str>) {
 }
 
 /// Returns true if `addr` is in the same network of `intf`.
-pub(crate) fn valid_ipv4_on_intf(addr: &Ipv4Addr, intf: &Ifv4Addr) -> bool {
-    let netmask = u32::from(intf.netmask);
-    let intf_net = u32::from(intf.ip) & netmask;
-    let addr_net = u32::from(*addr) & netmask;
-    addr_net == intf_net
+pub(crate) fn valid_ip_on_intf(addr: &IpAddr, intf: &Interface) -> bool {
+    match (addr, &intf.addr) {
+        (IpAddr::V4(addr), IfAddr::V4(intf)) => {
+            let netmask = u32::from(intf.netmask);
+            let intf_net = u32::from(intf.ip) & netmask;
+            let addr_net = u32::from(*addr) & netmask;
+            addr_net == intf_net
+        },
+        (IpAddr::V6(addr), IfAddr::V6(intf)) => {
+            let netmask = u128::from(intf.netmask);
+            let intf_net = u128::from(intf.ip) & netmask;
+            let addr_net = u128::from(*addr) & netmask;
+            addr_net == intf_net
+        },
+        _ => false
+    }
 }
 
 #[cfg(test)]

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "logging")]
 use crate::log::error;
 use crate::{Error, Result};
-use if_addrs::{Interface, IfAddr};
+use if_addrs::{IfAddr, Interface};
 use std::{
     collections::{HashMap, HashSet},
     convert::TryInto,
@@ -671,14 +671,14 @@ pub(crate) fn valid_ip_on_intf(addr: &IpAddr, intf: &Interface) -> bool {
             let intf_net = u32::from(intf.ip) & netmask;
             let addr_net = u32::from(*addr) & netmask;
             addr_net == intf_net
-        },
+        }
         (IpAddr::V6(addr), IfAddr::V6(intf)) => {
             let netmask = u128::from(intf.netmask);
             let intf_net = u128::from(intf.ip) & netmask;
             let addr_net = u128::from(*addr) & netmask;
             addr_net == intf_net
-        },
-        _ => false
+        }
+        _ => false,
     }
 }
 

--- a/tests/addr_parse.rs
+++ b/tests/addr_parse.rs
@@ -1,14 +1,14 @@
-use mdns_sd::AsIpv4Addrs;
+use mdns_sd::AsIpAddrs;
 use std::collections::HashSet;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr, IpAddr};
 
 #[test]
 fn test_addr_str() {
     assert_eq!(
-        "127.0.0.1".as_ipv4_addrs(),
+        "127.0.0.1".as_ip_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::new(127, 0, 0, 1));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1).into());
 
             set
         })
@@ -16,10 +16,10 @@ fn test_addr_str() {
 
     let addr = "127.0.0.1".to_string();
     assert_eq!(
-        addr.as_ipv4_addrs(),
+        addr.as_ip_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::new(127, 0, 0, 1));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1).into());
 
             set
         })
@@ -27,59 +27,92 @@ fn test_addr_str() {
 
     // verify that `&String` also works.
     assert_eq!(
-        (&addr).as_ipv4_addrs(),
+        (&addr).as_ip_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::new(127, 0, 0, 1));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1).into());
 
             set
         })
     );
 
     assert_eq!(
-        "127.0.0.1,127.0.0.2".as_ipv4_addrs(),
+        "127.0.0.1,127.0.0.2".as_ip_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::new(127, 0, 0, 1));
-            set.insert(Ipv4Addr::new(127, 0, 0, 2));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1).into());
+            set.insert(Ipv4Addr::new(127, 0, 0, 2).into());
+
+            set
+        })
+    );
+
+    let addr = "2001:db8::1".to_string();
+    assert_eq!(
+        addr.as_ip_addrs(),
+        Ok({
+            let mut set = HashSet::new();
+            set.insert(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1).into());
+
+            set
+        })
+    );
+
+    assert_eq!(
+        "2001:db8::1,2001:db8::2".as_ip_addrs(),
+        Ok({
+            let mut set = HashSet::new();
+            set.insert(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1).into());
+            set.insert(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 2).into());
 
             set
         })
     );
 
     // verify that an empty string parsed into an empty set.
-    assert_eq!("".as_ipv4_addrs(), Ok(HashSet::new()));
+    assert_eq!("".as_ip_addrs(), Ok(HashSet::new()));
 }
 
 #[test]
 fn test_addr_slice() {
     assert_eq!(
-        (&["127.0.0.1"][..]).as_ipv4_addrs(),
+        (&["127.0.0.1"][..]).as_ip_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::new(127, 0, 0, 1));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1).into());
 
             set
         })
     );
 
     assert_eq!(
-        (&["127.0.0.1", "127.0.0.2"][..]).as_ipv4_addrs(),
+        (&["127.0.0.1", "127.0.0.2"][..]).as_ip_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::new(127, 0, 0, 1));
-            set.insert(Ipv4Addr::new(127, 0, 0, 2));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1).into());
+            set.insert(Ipv4Addr::new(127, 0, 0, 2).into());
 
             set
         })
     );
 
     assert_eq!(
-        (&vec!["127.0.0.1", "127.0.0.2"][..]).as_ipv4_addrs(),
+        (&vec!["127.0.0.1", "127.0.0.2"][..]).as_ip_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::new(127, 0, 0, 1));
-            set.insert(Ipv4Addr::new(127, 0, 0, 2));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1).into());
+            set.insert(Ipv4Addr::new(127, 0, 0, 2).into());
+
+            set
+        })
+    );
+
+    assert_eq!(
+        (&vec!["2001:db8::1", "2001:db8::2"][..]).as_ip_addrs(),
+        Ok({
+            let mut set = HashSet::new();
+            set.insert(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1).into());
+            set.insert(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 2).into());
 
             set
         })
@@ -88,23 +121,23 @@ fn test_addr_slice() {
 
 #[test]
 fn test_addr_ip() {
-    let ip = Ipv4Addr::new(127, 0, 0, 1);
+    let ip: IpAddr = Ipv4Addr::new(127, 0, 0, 1).into();
 
     assert_eq!(
-        ip.as_ipv4_addrs(),
+        ip.as_ip_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::new(127, 0, 0, 1));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1).into());
 
             set
         })
     );
 
     assert_eq!(
-        (&ip).as_ipv4_addrs(),
+        (&ip).as_ip_addrs(),
         Ok({
             let mut set = HashSet::new();
-            set.insert(Ipv4Addr::new(127, 0, 0, 1));
+            set.insert(Ipv4Addr::new(127, 0, 0, 1).into());
 
             set
         })

--- a/tests/addr_parse.rs
+++ b/tests/addr_parse.rs
@@ -1,6 +1,6 @@
 use mdns_sd::AsIpAddrs;
 use std::collections::HashSet;
-use std::net::{Ipv4Addr, Ipv6Addr, IpAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 #[test]
 fn test_addr_str() {

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -3,7 +3,7 @@ use mdns_sd::{
     DaemonEvent, IntoTxtProperties, ServiceDaemon, ServiceEvent, ServiceInfo, UnregisterStatus,
 };
 use std::collections::HashMap;
-use std::net::{Ipv4Addr, Ipv6Addr, IpAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::{Duration, SystemTime};
@@ -223,7 +223,10 @@ fn service_without_properties_with_alter_net_v4() {
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
     let instance_name = now.as_micros().to_string(); // Create a unique name.
-    let if_addrs: Vec<Interface> = my_ip_interfaces().into_iter().filter(|iface| iface.addr.ip().is_ipv4()).collect();
+    let if_addrs: Vec<Interface> = my_ip_interfaces()
+        .into_iter()
+        .filter(|iface| iface.addr.ip().is_ipv4())
+        .collect();
     let first_ip = if_addrs[0].ip();
     let alter_ip = ipv4_alter_net(&if_addrs);
     let host_ip = vec![first_ip, alter_ip];
@@ -259,7 +262,11 @@ fn service_without_properties_with_alter_net_v4() {
                     );
                     // match only our service and not v6 one
                     if fullname.as_str() == info.get_fullname() {
-                        let addrs: Vec<&IpAddr> = info.get_addresses().into_iter().filter(|a| a.is_ipv4()).collect();
+                        let addrs: Vec<&IpAddr> = info
+                            .get_addresses()
+                            .into_iter()
+                            .filter(|a| a.is_ipv4())
+                            .collect();
                         assert_eq!(addrs.len(), 1); // first_ipv4 but no alter_ipv.
                         found = true;
                         break;
@@ -291,7 +298,10 @@ fn service_without_properties_with_alter_net_v6() {
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
     let instance_name = now.as_micros().to_string(); // Create a unique name.
-    let if_addrs: Vec<Interface> = my_ip_interfaces().into_iter().filter(|iface| iface.addr.ip().is_ipv6()).collect();
+    let if_addrs: Vec<Interface> = my_ip_interfaces()
+        .into_iter()
+        .filter(|iface| iface.addr.ip().is_ipv6())
+        .collect();
     let first_ip = if_addrs[0].ip();
     let alter_ip = ipv6_alter_net(&if_addrs);
     let host_ip = vec![first_ip, alter_ip];
@@ -327,7 +337,11 @@ fn service_without_properties_with_alter_net_v6() {
                     );
                     // match only our service and not v4 one
                     if fullname.as_str() == info.get_fullname() {
-                        let addrs: Vec<&IpAddr> = info.get_addresses().into_iter().filter(|a| a.is_ipv6()).collect();
+                        let addrs: Vec<&IpAddr> = info
+                            .get_addresses()
+                            .into_iter()
+                            .filter(|a| a.is_ipv6())
+                            .collect();
                         assert_eq!(addrs.len(), 1); // first_ipv6 but no alter_ipv.
                         found = true;
                         break;
@@ -439,19 +453,15 @@ fn service_with_invalid_addr_v4() {
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
     let instance_name = now.as_micros().to_string(); // Create a unique name.
-    let if_addrs: Vec<Interface> = my_ip_interfaces().into_iter().filter(|iface| iface.addr.ip().is_ipv4()).collect();
+    let if_addrs: Vec<Interface> = my_ip_interfaces()
+        .into_iter()
+        .filter(|iface| iface.addr.ip().is_ipv4())
+        .collect();
     let alter_ip = ipv4_alter_net(&if_addrs);
     let host_name = "my_host.";
     let port = 5201;
-    let my_service = ServiceInfo::new(
-        ty_domain,
-        &instance_name,
-        host_name,
-        &alter_ip,
-        port,
-        None,
-    )
-    .expect("valid service info");
+    let my_service = ServiceInfo::new(ty_domain, &instance_name, host_name, &alter_ip, port, None)
+        .expect("valid service info");
     d.register(my_service)
         .expect("Failed to register our service");
 
@@ -500,19 +510,15 @@ fn service_with_invalid_addr_v6() {
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
     let instance_name = now.as_micros().to_string(); // Create a unique name.
-    let if_addrs: Vec<Interface> = my_ip_interfaces().into_iter().filter(|iface| iface.addr.ip().is_ipv6()).collect();
+    let if_addrs: Vec<Interface> = my_ip_interfaces()
+        .into_iter()
+        .filter(|iface| iface.addr.ip().is_ipv6())
+        .collect();
     let alter_ip = ipv6_alter_net(&if_addrs);
     let host_name = "my_host.";
     let port = 5201;
-    let my_service = ServiceInfo::new(
-        ty_domain,
-        &instance_name,
-        host_name,
-        &alter_ip,
-        port,
-        None,
-    )
-    .expect("valid service info");
+    let my_service = ServiceInfo::new(ty_domain, &instance_name, host_name, &alter_ip, port, None)
+        .expect("valid service info");
     d.register(my_service)
         .expect("Failed to register our service");
 
@@ -844,7 +850,7 @@ fn ipv6_alter_net(if_addrs: &[Interface]) -> IpAddr {
                 if net > net_max {
                     net_max = net;
                 }
-            },
+            }
             _ => panic!(),
         }
     }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -2,7 +2,7 @@ use if_addrs::{IfAddr, Interface};
 use mdns_sd::{
     DaemonEvent, IntoTxtProperties, ServiceDaemon, ServiceEvent, ServiceInfo, UnregisterStatus,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
@@ -22,7 +22,8 @@ fn integration_success() {
         .unwrap();
     let instance_name = now.as_micros().to_string(); // Create a unique name.
 
-    let my_ifaddrs: Vec<_> = my_ip_interfaces().iter().map(|intf| intf.ip()).collect();
+    let ifaddrs_set: HashSet<_> = my_ip_interfaces().iter().map(|intf| intf.ip()).collect();
+    let my_ifaddrs: Vec<_> = ifaddrs_set.into_iter().collect();
     let my_addrs_count = my_ifaddrs.len();
     println!("My IP addr(s): {:?}", &my_ifaddrs);
 

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1,9 +1,9 @@
-use if_addrs::{IfAddr, Ifv4Addr};
+use if_addrs::{IfAddr, Interface};
 use mdns_sd::{
     DaemonEvent, IntoTxtProperties, ServiceDaemon, ServiceEvent, ServiceInfo, UnregisterStatus,
 };
 use std::collections::HashMap;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr, IpAddr};
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::{Duration, SystemTime};
@@ -22,9 +22,9 @@ fn integration_success() {
         .unwrap();
     let instance_name = now.as_micros().to_string(); // Create a unique name.
 
-    let my_ifaddrs: Vec<_> = my_ipv4_interfaces().iter().map(|intf| intf.ip).collect();
+    let my_ifaddrs: Vec<_> = my_ip_interfaces().iter().map(|intf| intf.ip()).collect();
     let my_addrs_count = my_ifaddrs.len();
-    println!("My IPv4 addr(s): {:?}", &my_ifaddrs);
+    println!("My IP addr(s): {:?}", &my_ifaddrs);
 
     let host_name = "my_host.";
     let port = 5200;
@@ -213,7 +213,7 @@ fn integration_success() {
 }
 
 #[test]
-fn service_without_properties_with_alter_net() {
+fn service_without_properties_with_alter_net_v4() {
     // Create a daemon
     let d = ServiceDaemon::new().expect("Failed to create daemon");
 
@@ -223,17 +223,17 @@ fn service_without_properties_with_alter_net() {
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
     let instance_name = now.as_micros().to_string(); // Create a unique name.
-    let ifv4_addrs = &my_ipv4_interfaces();
-    let first_ipv4 = ifv4_addrs[0].ip;
-    let alter_ipv4 = ipv4_alter_net(ifv4_addrs);
-    let host_ipv4 = vec![first_ipv4, alter_ipv4];
+    let if_addrs: Vec<Interface> = my_ip_interfaces().into_iter().filter(|iface| iface.addr.ip().is_ipv4()).collect();
+    let first_ip = if_addrs[0].ip();
+    let alter_ip = ipv4_alter_net(&if_addrs);
+    let host_ip = vec![first_ip, alter_ip];
     let host_name = "serv-no-prop.";
     let port = 5201;
     let my_service = ServiceInfo::new(
         ty_domain,
         &instance_name,
         host_name,
-        &host_ipv4[..],
+        &host_ip[..],
         port,
         None,
     )
@@ -241,12 +241,14 @@ fn service_without_properties_with_alter_net() {
     let fullname = my_service.get_fullname().to_string();
     d.register(my_service)
         .expect("Failed to register our service");
-    println!("Registered service with host_ipv4: {:?}", &host_ipv4);
+    println!("Registered service with host_ip: {:?}", &host_ip);
 
     // Browse for a service
     let browse_chan = d.browse(ty_domain).unwrap();
     let timeout = Duration::from_secs(2);
-    loop {
+    let timer = std::time::Instant::now() + timeout;
+    let mut found = false;
+    while std::time::Instant::now() < timer {
         match browse_chan.recv_timeout(timeout) {
             Ok(event) => match event {
                 ServiceEvent::ServiceResolved(info) => {
@@ -255,10 +257,13 @@ fn service_without_properties_with_alter_net() {
                         &info.get_fullname(),
                         info.get_addresses()
                     );
-                    assert_eq!(fullname.as_str(), info.get_fullname());
-                    let addrs = info.get_addresses();
-                    assert_eq!(addrs.len(), 1); // first_ipv4 but no alter_ipv4.
-                    break;
+                    // match only our service and not v6 one
+                    if fullname.as_str() == info.get_fullname() {
+                        let addrs: Vec<&IpAddr> = info.get_addresses().into_iter().filter(|a| a.is_ipv4()).collect();
+                        assert_eq!(addrs.len(), 1); // first_ipv4 but no alter_ipv.
+                        found = true;
+                        break;
+                    }
                 }
                 e => {
                     println!("Received event {:?}", e);
@@ -272,6 +277,75 @@ fn service_without_properties_with_alter_net() {
     }
 
     d.shutdown().unwrap();
+    assert!(found);
+}
+
+#[test]
+fn service_without_properties_with_alter_net_v6() {
+    // Create a daemon
+    let d = ServiceDaemon::new().expect("Failed to create daemon");
+
+    // Register a service without properties.
+    let ty_domain = "_serv-no-prop._tcp.local.";
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap();
+    let instance_name = now.as_micros().to_string(); // Create a unique name.
+    let if_addrs: Vec<Interface> = my_ip_interfaces().into_iter().filter(|iface| iface.addr.ip().is_ipv6()).collect();
+    let first_ip = if_addrs[0].ip();
+    let alter_ip = ipv6_alter_net(&if_addrs);
+    let host_ip = vec![first_ip, alter_ip];
+    let host_name = "serv-no-prop.";
+    let port = 5201;
+    let my_service = ServiceInfo::new(
+        ty_domain,
+        &instance_name,
+        host_name,
+        &host_ip[..],
+        port,
+        None,
+    )
+    .expect("valid service info");
+    let fullname = my_service.get_fullname().to_string();
+    d.register(my_service)
+        .expect("Failed to register our service");
+    println!("Registered service with host_ip: {:?}", &host_ip);
+
+    // Browse for a service
+    let browse_chan = d.browse(ty_domain).unwrap();
+    let timeout = Duration::from_secs(2);
+    let timer = std::time::Instant::now() + timeout;
+    let mut found = false;
+    while std::time::Instant::now() < timer {
+        match browse_chan.recv_timeout(timeout) {
+            Ok(event) => match event {
+                ServiceEvent::ServiceResolved(info) => {
+                    println!(
+                        "Resolved a service of {} addr(s): {:?}",
+                        &info.get_fullname(),
+                        info.get_addresses()
+                    );
+                    // match only our service and not v4 one
+                    if fullname.as_str() == info.get_fullname() {
+                        let addrs: Vec<&IpAddr> = info.get_addresses().into_iter().filter(|a| a.is_ipv6()).collect();
+                        assert_eq!(addrs.len(), 1); // first_ipv6 but no alter_ipv.
+                        found = true;
+                        break;
+                    }
+                }
+                e => {
+                    println!("Received event {:?}", e);
+                }
+            },
+            Err(e) => {
+                println!("browse error: {}", e);
+                assert!(false);
+            }
+        }
+    }
+
+    d.shutdown().unwrap();
+    assert!(found);
 }
 
 #[test]
@@ -355,7 +429,7 @@ fn test_into_txt_properties() {
 }
 
 #[test]
-fn service_with_invalid_addr() {
+fn service_with_invalid_addr_v4() {
     // Create a daemon
     let d = ServiceDaemon::new().expect("Failed to create daemon");
 
@@ -365,15 +439,76 @@ fn service_with_invalid_addr() {
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
     let instance_name = now.as_micros().to_string(); // Create a unique name.
-    let ifv4_addrs = &my_ipv4_interfaces();
-    let alter_ipv4 = ipv4_alter_net(ifv4_addrs);
+    let if_addrs: Vec<Interface> = my_ip_interfaces().into_iter().filter(|iface| iface.addr.ip().is_ipv4()).collect();
+    let alter_ip = ipv4_alter_net(&if_addrs);
     let host_name = "my_host.";
     let port = 5201;
     let my_service = ServiceInfo::new(
         ty_domain,
         &instance_name,
         host_name,
-        &alter_ipv4,
+        &alter_ip,
+        port,
+        None,
+    )
+    .expect("valid service info");
+    d.register(my_service)
+        .expect("Failed to register our service");
+
+    // Browse for a service
+    let browse_chan = d.browse(ty_domain).unwrap();
+    let timeout = Duration::from_secs(2);
+    let mut resolved = false;
+    loop {
+        match browse_chan.recv_timeout(timeout) {
+            Ok(event) => match event {
+                ServiceEvent::ServiceResolved(info) => {
+                    println!(
+                        "Resolved a service of {} addr(s): {:?}",
+                        &info.get_fullname(),
+                        info.get_addresses()
+                    );
+                    resolved = true;
+                    break;
+                }
+                e => {
+                    println!("Received event {:?}", e);
+                }
+            },
+            Err(e) => {
+                println!("browse error: {}", e);
+                break;
+            }
+        }
+    }
+
+    d.shutdown().unwrap();
+
+    // We cannot resolve the service because the published address
+    // is not valid in the LAN.
+    assert_eq!(resolved, false);
+}
+
+#[test]
+fn service_with_invalid_addr_v6() {
+    // Create a daemon
+    let d = ServiceDaemon::new().expect("Failed to create daemon");
+
+    // Register a service without properties.
+    let ty_domain = "_invalid-addr._tcp.local.";
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap();
+    let instance_name = now.as_micros().to_string(); // Create a unique name.
+    let if_addrs: Vec<Interface> = my_ip_interfaces().into_iter().filter(|iface| iface.addr.ip().is_ipv6()).collect();
+    let alter_ip = ipv6_alter_net(&if_addrs);
+    let host_name = "my_host.";
+    let port = 5201;
+    let my_service = ServiceInfo::new(
+        ty_domain,
+        &instance_name,
+        host_name,
+        &alter_ip,
         port,
         None,
     )
@@ -427,7 +562,7 @@ fn subtype() {
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
     let instance_name = now.as_micros().to_string(); // Create a unique name.
-    let host_ipv4 = my_ipv4_interfaces()[0].ip.to_string();
+    let host_ipv4 = my_ip_interfaces()[0].ip().to_string();
     let host_name = "my_host.";
     let port = 5201;
     let my_service = ServiceInfo::new(
@@ -632,7 +767,7 @@ fn instance_name_two_dots() {
     server_daemon.shutdown().unwrap();
 }
 
-fn my_ipv4_interfaces() -> Vec<Ifv4Addr> {
+fn my_ip_interfaces() -> Vec<Interface> {
     // Use a random port for binding test.
     let test_port = fastrand::u16(8000u16..9000u16);
 
@@ -643,19 +778,31 @@ fn my_ipv4_interfaces() -> Vec<Ifv4Addr> {
             if i.is_loopback() {
                 None
             } else {
-                match i.addr {
+                match &i.addr {
                     IfAddr::V4(ifv4) =>
                     // Use a 'bind' to check if this is a valid IPv4 addr.
                     {
                         match std::net::UdpSocket::bind((ifv4.ip, test_port)) {
-                            Ok(_) => Some(ifv4),
+                            Ok(_) => Some(i),
                             Err(e) => {
                                 println!("bind {}: {}, skipped.", ifv4.ip, e);
                                 None
                             }
                         }
                     }
-                    _ => None,
+                    IfAddr::V6(ifv6) =>
+                    // Use a 'bind' to check if this is a valid IPv6 addr.
+                    {
+                        let mut sock = std::net::SocketAddrV6::new(ifv6.ip, test_port, 0, 0);
+                        sock.set_scope_id(i.index.unwrap_or(0));
+                        match std::net::UdpSocket::bind(sock) {
+                            Ok(_) => Some(i),
+                            Err(e) => {
+                                println!("bind {}: {}, skipped.", ifv6.ip, e);
+                                None
+                            }
+                        }
+                    }
                 }
             }
         })
@@ -667,13 +814,39 @@ fn my_ipv4_interfaces() -> Vec<Ifv4Addr> {
 ///
 /// The idea is that this made-up address does not belong to
 /// the same network as any of the host addresses.
-fn ipv4_alter_net(ifv4_addrs: &Vec<Ifv4Addr>) -> Ipv4Addr {
+fn ipv4_alter_net(if_addrs: &[Interface]) -> IpAddr {
     let mut net_max = 0;
-    for ifv4_addr in ifv4_addrs.iter() {
-        let net = ifv4_addr.ip.octets()[0];
-        if net > net_max {
-            net_max = net;
+    for if_addr in if_addrs.iter() {
+        match &if_addr.addr {
+            IfAddr::V4(iface) => {
+                let net = iface.ip.octets()[0];
+                if net > net_max {
+                    net_max = net;
+                }
+            }
+            _ => panic!(),
         }
     }
-    Ipv4Addr::new(net_max + 1, 1, 1, 1)
+    Ipv4Addr::new(net_max + 1, 1, 1, 1).into()
+}
+
+/// Returns a made-up IPv6 address "net:1:1:1:1:1:1:1", where
+/// `net` is one higher than any of IPv6 addresses on the host.
+///
+/// The idea is that this made-up address does not belong to
+/// the same network as any of the host addresses.
+fn ipv6_alter_net(if_addrs: &[Interface]) -> IpAddr {
+    let mut net_max = 0;
+    for if_addr in if_addrs.iter() {
+        match &if_addr.addr {
+            IfAddr::V6(iface) => {
+                let net = iface.ip.octets()[0];
+                if net > net_max {
+                    net_max = net;
+                }
+            },
+            _ => panic!(),
+        }
+    }
+    Ipv6Addr::new(net_max as u16 + 1, 1, 1, 1, 1, 1, 1, 1).into()
 }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -123,14 +123,14 @@ fn integration_success() {
     });
 
     // Wait a bit to let the daemon process commands in the channel.
-    sleep(Duration::from_millis(1200));
+    sleep(Duration::from_secs(2));
 
     // Unregister the service
     let receiver = d.unregister(&fullname).unwrap();
     let response = receiver.recv().unwrap();
     assert!(matches!(response, UnregisterStatus::OK));
 
-    sleep(Duration::from_secs(1));
+    sleep(Duration::from_secs(2));
 
     // All addrs should have been resolved.
     let count = addr_count.lock().unwrap();


### PR DESCRIPTION
Add ipv6 and AAAA records support

This will probably need a version bump as the interface is slightly modified

It now takes `IpAddr` and `if_addr::Interface` types in most places instead of the V4 ones
`host_ipv4` argument renamed to `ip`
`AsIpv4Addrs` renamed to `AsIpAddrs`

- [x] dns_parser: support "AAAA" address record.
- [x] responder: support register ServiceInfo with IPv4 only or IPv6 only, as well as both IPv4 and IPv6 in one register.
- [x] responder: recv and process queries on IPv6 interfaces if IPv6 address is configured.
- [x] responder: send response on IPv6 interface if IPv6 address is configured.
- [x] querier: send query on IPv6 interface if IPv6 address is configured.
- [x] querier: recv and handle answers on IPv6 interfaces if IPv6 address is configured.
- [x] Default setting: both IPv4 and IPv6 is enabled (if addr is configured). Provides API to disable IPv6 (or IPv4). i.e. allow the ServiceDaemon to be IPv6 only or IPv4 only.
- [x] Tests

The reviewer should look at the diff per commit as it is easier to read

Fix #61