### PR TITLE
ServiceInfo: support get_addresses_v4

### DIFF
--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -203,12 +203,12 @@ impl ServiceInfo {
     }
 
     /// Returns the service's IPv4 addresses only.
-    pub fn get_addresses_v4(&self) -> HashSet<Ipv4Addr> {
+    pub fn get_addresses_v4(&self) -> HashSet<&Ipv4Addr> {
         let mut ipv4_addresses = HashSet::new();
 
         for ip in &self.addresses {
             if let IpAddr::V4(ipv4) = ip {
-                ipv4_addresses.insert(*ipv4);
+                ipv4_addresses.insert(ipv4);
             }
         }
 

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -6,7 +6,7 @@ use std::{
     collections::{HashMap, HashSet},
     convert::TryInto,
     fmt,
-    net::IpAddr,
+    net::{IpAddr, Ipv4Addr},
     str::FromStr,
 };
 
@@ -200,6 +200,19 @@ impl ServiceInfo {
     #[inline]
     pub fn get_addresses(&self) -> &HashSet<IpAddr> {
         &self.addresses
+    }
+
+    /// Returns the service's IPv4 addresses only.
+    pub fn get_addresses_v4(&self) -> HashSet<Ipv4Addr> {
+        let mut ipv4_addresses = HashSet::new();
+
+        for ip in &self.addresses {
+            if let IpAddr::V4(ipv4) = ip {
+                ipv4_addresses.insert(*ipv4);
+            }
+        }
+
+        ipv4_addresses
     }
 
     /// Returns the service's TTL used for SRV and Address records.

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -263,11 +263,7 @@ fn service_without_properties_with_alter_net_v4() {
                     );
                     // match only our service and not v6 one
                     if fullname.as_str() == info.get_fullname() {
-                        let addrs: Vec<&IpAddr> = info
-                            .get_addresses()
-                            .into_iter()
-                            .filter(|a| a.is_ipv4())
-                            .collect();
+                        let addrs = info.get_addresses_v4();
                         assert_eq!(addrs.len(), 1); // first_ipv4 but no alter_ipv.
                         found = true;
                         break;


### PR DESCRIPTION
This is to address issue #131 . By adding a new method to return Ipv4Addr only, a user can continue to call Ipv4 only methods.

I've not implemented a v6 version as the main purpose is for backward compatibility when the app was expecting to get IPv4 addresses.