### PR TITLE
support interface selection

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -966,13 +966,6 @@ impl DnsIncoming {
 
             // decode RDATA based on the record type.
             let rec: Option<DnsRecordBox> = match ty {
-                TYPE_A => Some(Box::new(DnsAddress::new(
-                    &name,
-                    ty,
-                    class,
-                    ttl,
-                    self.read_ipv4().into(),
-                ))),
                 TYPE_CNAME | TYPE_PTR => Some(Box::new(DnsPointer::new(
                     &name,
                     ty,
@@ -1003,6 +996,13 @@ impl DnsIncoming {
                     ttl,
                     self.read_char_string(),
                     self.read_char_string(),
+                ))),
+                TYPE_A => Some(Box::new(DnsAddress::new(
+                    &name,
+                    ty,
+                    class,
+                    ttl,
+                    self.read_ipv4().into(),
                 ))),
                 TYPE_AAAA => Some(Box::new(DnsAddress::new(
                     &name,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ mod service_info;
 
 pub use error::{Error, Result};
 pub use service_daemon::{
-    DaemonEvent, Metrics, ServiceDaemon, ServiceEvent, UnregisterStatus,
+    DaemonEvent, IfKind, Metrics, ServiceDaemon, ServiceEvent, UnregisterStatus,
     SERVICE_NAME_LEN_MAX_DEFAULT,
 };
 pub use service_info::{AsIpAddrs, IntoTxtProperties, ServiceInfo, TxtProperties, TxtProperty};

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -988,7 +988,7 @@ impl Zeroconf {
             }
         }
 
-        // Remove the interfaces not selected.
+        // Update `intf_socks` based on the selections.
         for (idx, intf) in interfaces.into_iter().enumerate() {
             let ip_addr = intf.ip();
 
@@ -1008,8 +1008,6 @@ impl Zeroconf {
                 }
             }
         }
-
-        // Add the interfaces as needed.
     }
 
     /// Check for IP changes and update intf_socks as needed.

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -704,11 +704,6 @@ struct IntfSock {
     sock: Socket,
 }
 
-struct IfSelection {
-    if_kind: IfKind,
-    selected: bool,
-}
-
 /// Specify kinds of interfaces.
 /// This type is used to enable or to disable interfaces in the daemon.
 #[derive(Debug, Clone)]
@@ -729,7 +724,7 @@ pub enum IfKind {
 
 impl IfKind {
     /// Checks if `intf` matches with this interface kind.
-    pub fn matches(&self, intf: &Interface) -> bool {
+    fn matches(&self, intf: &Interface) -> bool {
         match self {
             IfKind::All => true,
             IfKind::IPv4 => intf.ip().is_ipv4(),
@@ -739,6 +734,7 @@ impl IfKind {
     }
 }
 
+/// A trait that converts a type into a Vec of `IfKind`.
 pub trait IfKindIter {
     fn into_vec(self) -> IfKindVec;
 }
@@ -757,6 +753,15 @@ impl IfKindIter for Vec<IfKind> {
     fn into_vec(self) -> IfKindVec {
         IfKindVec { kinds: self }
     }
+}
+
+/// Selection of interfaces.
+struct IfSelection {
+    /// The interfaces to be selected.
+    if_kind: IfKind,
+
+    /// Whether the `if_kind` should be enabled or not.
+    selected: bool,
 }
 
 /// A struct holding the state. It was inspired by `zeroconf` package in Python.
@@ -792,6 +797,7 @@ struct Zeroconf {
     /// Options
     service_name_len_max: u8,
 
+    /// All interface selections called to the daemon.
     if_selections: Vec<IfSelection>,
 
     /// Socket for signaling.

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -294,14 +294,14 @@ impl ServiceDaemon {
     }
 
     pub fn enable_interface(&self, if_kind: impl IfKindIterator) -> Result<()> {
-        let iter = if_kind.into_iter();
+        let iter = if_kind.into_vec();
         self.send_cmd(Command::SetOption(DaemonOption::EnableInterface(
             iter.kinds,
         )))
     }
 
     pub fn disable_interface(&self, if_kind: impl IfKindIterator) -> Result<()> {
-        let iter = if_kind.into_iter();
+        let iter = if_kind.into_vec();
         self.send_cmd(Command::SetOption(DaemonOption::DisableInterface(
             iter.kinds,
         )))
@@ -734,22 +734,22 @@ impl IfKind {
 }
 
 pub trait IfKindIterator {
-    fn into_iter(self) -> IfKindIter;
+    fn into_vec(self) -> IfKindVec;
 }
 
-pub struct IfKindIter {
+pub struct IfKindVec {
     kinds: Vec<IfKind>,
 }
 
 impl IfKindIterator for IfKind {
-    fn into_iter(self) -> IfKindIter {
-        IfKindIter { kinds: vec![self] }
+    fn into_vec(self) -> IfKindVec {
+        IfKindVec { kinds: vec![self] }
     }
 }
 
 impl IfKindIterator for Vec<IfKind> {
-    fn into_iter(self) -> IfKindIter {
-        IfKindIter { kinds: self }
+    fn into_vec(self) -> IfKindVec {
+        IfKindVec { kinds: self }
     }
 }
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -720,7 +720,7 @@ pub enum IfKind {
     /// By the interface name, for example "en0"
     Name(String),
 
-    /// By the address type.
+    /// By an IPv4 or IPv6 address.
     Addr(IpAddr),
 }
 
@@ -739,26 +739,27 @@ impl IfKind {
 
 /// The first use case of specifying an interface was to
 /// use an interface name. Hence adding this for ergonomic reasons.
-impl Into<IfKind> for &str {
-    fn into(self) -> IfKind {
-        IfKind::Name(self.to_string())
+impl From<&str> for IfKind {
+    fn from(val: &str) -> IfKind {
+        IfKind::Name(val.to_string())
     }
 }
 
 /// Still for ergonomic reasons.
-impl Into<IfKind> for IpAddr {
-    fn into(self) -> IfKind {
-        IfKind::Addr(self)
+impl From<IpAddr> for IfKind {
+    fn from(val: IpAddr) -> IfKind {
+        IfKind::Addr(val)
     }
+}
+
+/// A list of `IfKind` that can be used to match interfaces.
+pub struct IfKindVec {
+    kinds: Vec<IfKind>,
 }
 
 /// A trait that converts a type into a Vec of `IfKind`.
 pub trait IntoIfKindVec {
     fn into_vec(self) -> IfKindVec;
-}
-
-pub struct IfKindVec {
-    kinds: Vec<IfKind>,
 }
 
 impl<T: Into<IfKind>> IntoIfKindVec for T {

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -296,7 +296,7 @@ impl ServiceDaemon {
     /// Include interfaces that match `if_kind` for this service daemon.
     ///
     /// For example:
-    /// ```rust,no_run
+    /// ```ignore
     ///     daemon.enable_interface("en0")?;
     /// ```
     pub fn enable_interface(&self, if_kind: impl IntoIfKindVec) -> Result<()> {
@@ -309,7 +309,7 @@ impl ServiceDaemon {
     /// Ignore/exclude interfaces that match `if_kind` for this daemon.
     ///
     /// For example:
-    /// ```rust,no_run
+    /// ```ignore
     ///     daemon.disable_interface(IfKind::IPv6)?;
     /// ```
     pub fn disable_interface(&self, if_kind: impl IntoIfKindVec) -> Result<()> {

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1404,7 +1404,7 @@ impl Zeroconf {
             }
         }
 
-        // resolve A records
+        // resolve A and AAAA records
         if let Some(records) = self.cache.addr.get(info.get_hostname()) {
             for answer in records.iter() {
                 if let Some(dns_a) = answer.any().downcast_ref::<DnsAddress>() {

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -745,6 +745,12 @@ impl From<&str> for IfKind {
     }
 }
 
+impl From<&String> for IfKind {
+    fn from(val: &String) -> IfKind {
+        IfKind::Name(val.to_string())
+    }
+}
+
 /// Still for ergonomic reasons.
 impl From<IpAddr> for IfKind {
     fn from(val: IpAddr) -> IfKind {

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -805,6 +805,8 @@ impl Zeroconf {
             if_kind,
             selected: false,
         });
+
+        self.process_if_selections();
     }
 
     fn notify_monitors(&mut self, event: DaemonEvent) {
@@ -856,6 +858,7 @@ impl Zeroconf {
         key
     }
 
+    /// Apply all selections to the available interfaces.
     fn process_if_selections(&mut self) {
         // By default, we enable all interfaces.
         let interfaces = my_ip_interfaces();

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -708,16 +708,22 @@ struct IfSelection {
 }
 
 /// Specify kinds of interfaces.
+/// This type is used to enable or to disable interfaces in the daemon.
 #[derive(Debug, Clone)]
 pub enum IfKind {
+    /// All interfaces.
     All,
+
+    /// All IPv4 interfaces.
     IPv4,
+
+    /// All IPv6 interfaces.
     IPv6,
 
     /// By the interface name, for example "en0"
     Name(String),
 
-    /// By the interface address, for example "192.168.0.1"
+    /// By the interface address, for example IPv4 "192.168.0.1"
     Addr(IpAddr),
 }
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -710,6 +710,7 @@ struct IfSelection {
 /// Specify kinds of interfaces.
 /// This type is used to enable or to disable interfaces in the daemon.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum IfKind {
     /// All interfaces.
     All,
@@ -722,9 +723,6 @@ pub enum IfKind {
 
     /// By the interface name, for example "en0"
     Name(String),
-
-    /// By the interface address, for example IPv4 "192.168.0.1"
-    Addr(IpAddr),
 }
 
 impl IfKind {
@@ -734,7 +732,7 @@ impl IfKind {
             IfKind::All => true,
             IfKind::IPv4 => intf.ip().is_ipv4(),
             IfKind::IPv6 => intf.ip().is_ipv6(),
-            _ => false,
+            IfKind::Name(ifname) => ifname == &intf.name,
         }
     }
 }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -294,16 +294,16 @@ impl ServiceDaemon {
     }
 
     pub fn enable_interface(&self, if_kind: impl IfKindIter) -> Result<()> {
-        let iter = if_kind.into_vec();
+        let if_kind_vec = if_kind.into_vec();
         self.send_cmd(Command::SetOption(DaemonOption::EnableInterface(
-            iter.kinds,
+            if_kind_vec.kinds,
         )))
     }
 
     pub fn disable_interface(&self, if_kind: impl IfKindIter) -> Result<()> {
-        let iter = if_kind.into_vec();
+        let if_kind_vec = if_kind.into_vec();
         self.send_cmd(Command::SetOption(DaemonOption::DisableInterface(
-            iter.kinds,
+            if_kind_vec.kinds,
         )))
     }
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -294,6 +294,11 @@ impl ServiceDaemon {
     }
 
     /// Include interfaces that match `if_kind` for this service daemon.
+    ///
+    /// For example:
+    /// ```rust,no_run
+    ///     daemon.enable_interface("en0")?;
+    /// ```
     pub fn enable_interface(&self, if_kind: impl IntoIfKindVec) -> Result<()> {
         let if_kind_vec = if_kind.into_vec();
         self.send_cmd(Command::SetOption(DaemonOption::EnableInterface(
@@ -302,6 +307,11 @@ impl ServiceDaemon {
     }
 
     /// Ignore/exclude interfaces that match `if_kind` for this daemon.
+    ///
+    /// For example:
+    /// ```rust,no_run
+    ///     daemon.disable_interface(IfKind::IPv6)?;
+    /// ```
     pub fn disable_interface(&self, if_kind: impl IntoIfKindVec) -> Result<()> {
         let if_kind_vec = if_kind.into_vec();
         self.send_cmd(Command::SetOption(DaemonOption::DisableInterface(
@@ -703,8 +713,9 @@ struct IntfSock {
     sock: Socket,
 }
 
-/// Specify kinds of interfaces.
-/// This type is used to enable or to disable interfaces in the daemon.
+/// Specify kinds of interfaces. It is used to enable or to disable interfaces in the daemon.
+///
+/// Note that for ergonomic reasons, `From<&str>` and `From<IpAddr>` are implemented.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum IfKind {

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -293,6 +293,7 @@ impl ServiceDaemon {
         self.send_cmd(Command::SetOption(DaemonOption::ServiceNameLenMax(len_max)))
     }
 
+    /// Include interfaces that match `if_kind` for this service daemon.
     pub fn enable_interface(&self, if_kind: impl IfKindIter) -> Result<()> {
         let if_kind_vec = if_kind.into_vec();
         self.send_cmd(Command::SetOption(DaemonOption::EnableInterface(
@@ -300,6 +301,7 @@ impl ServiceDaemon {
         )))
     }
 
+    /// Ignore/exclude interfaces that match `if_kind` for this daemon.
     pub fn disable_interface(&self, if_kind: impl IfKindIter) -> Result<()> {
         let if_kind_vec = if_kind.into_vec();
         self.send_cmd(Command::SetOption(DaemonOption::DisableInterface(

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -38,7 +38,7 @@ use crate::{
         TYPE_TXT,
     },
     error::{Error, Result},
-    service_info::{ifaddr_netmask, split_sub_domain, IfKind, IfSelection, ServiceInfo},
+    service_info::{ifaddr_netmask, split_sub_domain, IfKind, ServiceInfo},
     Receiver,
 };
 use flume::{bounded, Sender, TrySendError};
@@ -694,6 +694,11 @@ struct ReRun {
 struct IntfSock {
     intf: Interface,
     sock: Socket,
+}
+
+struct IfSelection {
+    if_kind: IfKind,
+    selected: bool,
 }
 
 /// A struct holding the state. It was inspired by `zeroconf` package in Python.

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -293,14 +293,14 @@ impl ServiceDaemon {
         self.send_cmd(Command::SetOption(DaemonOption::ServiceNameLenMax(len_max)))
     }
 
-    pub fn enable_interface(&self, if_kind: impl IfKindIterator) -> Result<()> {
+    pub fn enable_interface(&self, if_kind: impl IfKindIter) -> Result<()> {
         let iter = if_kind.into_vec();
         self.send_cmd(Command::SetOption(DaemonOption::EnableInterface(
             iter.kinds,
         )))
     }
 
-    pub fn disable_interface(&self, if_kind: impl IfKindIterator) -> Result<()> {
+    pub fn disable_interface(&self, if_kind: impl IfKindIter) -> Result<()> {
         let iter = if_kind.into_vec();
         self.send_cmd(Command::SetOption(DaemonOption::DisableInterface(
             iter.kinds,
@@ -733,7 +733,7 @@ impl IfKind {
     }
 }
 
-pub trait IfKindIterator {
+pub trait IfKindIter {
     fn into_vec(self) -> IfKindVec;
 }
 
@@ -741,13 +741,13 @@ pub struct IfKindVec {
     kinds: Vec<IfKind>,
 }
 
-impl IfKindIterator for IfKind {
+impl IfKindIter for IfKind {
     fn into_vec(self) -> IfKindVec {
         IfKindVec { kinds: vec![self] }
     }
 }
 
-impl IfKindIterator for Vec<IfKind> {
+impl IfKindIter for Vec<IfKind> {
     fn into_vec(self) -> IfKindVec {
         IfKindVec { kinds: self }
     }

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -735,21 +735,7 @@ pub struct IfSelection {
 
 #[cfg(test)]
 mod tests {
-    use super::{decode_txt, encode_txt, u8_slice_to_hex, IfKind, ServiceInfo, TxtProperty};
-
-    #[test]
-    fn test_ifkind() {
-        let single_ifkind = IfKind::IPv4;
-        let vec_ifkind = vec![IfKind::IPv6, IfKind::Name("en0".to_string())];
-
-        for item in single_ifkind {
-            println!("{:?}", item);
-        }
-
-        for item in vec_ifkind {
-            println!("{:?}", item);
-        }
-    }
+    use super::{decode_txt, encode_txt, u8_slice_to_hex, ServiceInfo, TxtProperty};
 
     #[test]
     fn test_txt_encode_decode() {

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -42,6 +42,11 @@ impl ServiceInfo {
     ///
     /// `my_name` is the instance name, without the service type suffix.
     ///
+    /// `host_name` is the "host" in the context of DNS. It is used as the "name"
+    /// in the address records (i.e. TYPE_A and TYPE_AAAA records). It means that
+    /// for the same hostname in the same local network, the service resolves in
+    /// the same addresses. Be sure to check it if you see unexpected addresses resolved.
+    ///
     /// `properties` can be `None` or key/value string pairs, in a type that
     /// implements [`IntoTxtProperties`] trait. It supports:
     /// - `HashMap<String, String>`

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -17,7 +17,7 @@ const DNS_OTHER_TTL: u32 = 4500; // 75 minutes for non-host records (PTR, TXT et
 /// Complete info about a Service Instance.
 ///
 /// We can construct some PTR, one SRV and one TXT record from this info,
-/// as well as A (IPv4 Address) records.
+/// as well as A (IPv4 Address) and AAAA (IPv6 Address) records.
 #[derive(Debug, Clone)]
 pub struct ServiceInfo {
     ty_domain: String,          // <service>.<domain>
@@ -703,9 +703,53 @@ pub(crate) fn ifaddr_netmask(addr: &IfAddr) -> u128 {
     }
 }
 
+/// Specify kinds of interfaces.
+#[derive(Debug, Clone)]
+pub enum IfKind {
+    All,
+    IPv4,
+    IPv6,
+
+    /// By the interface name, for example "en0"
+    Name(String),
+
+    /// By the interface address, for example "192.168.0.1"
+    Addr(IpAddr),
+}
+
+impl IfKind {
+    /// Checks if `intf` matches with this interface kind.
+    pub fn matches(&self, intf: &Interface) -> bool {
+        match self {
+            IfKind::All => true,
+            IfKind::IPv4 => intf.ip().is_ipv4(),
+            IfKind::IPv6 => intf.ip().is_ipv6(),
+            _ => false,
+        }
+    }
+}
+pub struct IfSelection {
+    pub if_kind: IfKind,
+    pub selected: bool,
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{decode_txt, encode_txt, u8_slice_to_hex, ServiceInfo, TxtProperty};
+    use super::{decode_txt, encode_txt, u8_slice_to_hex, IfKind, ServiceInfo, TxtProperty};
+
+    #[test]
+    fn test_ifkind() {
+        let single_ifkind = IfKind::IPv4;
+        let vec_ifkind = vec![IfKind::IPv6, IfKind::Name("en0".to_string())];
+
+        for item in single_ifkind {
+            println!("{:?}", item);
+        }
+
+        for item in vec_ifkind {
+            println!("{:?}", item);
+        }
+    }
 
     #[test]
     fn test_txt_encode_decode() {

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -728,11 +728,6 @@ impl IfKind {
         }
     }
 }
-pub struct IfSelection {
-    pub if_kind: IfKind,
-    pub selected: bool,
-}
-
 #[cfg(test)]
 mod tests {
     use super::{decode_txt, encode_txt, u8_slice_to_hex, ServiceInfo, TxtProperty};

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -703,31 +703,6 @@ pub(crate) fn ifaddr_netmask(addr: &IfAddr) -> u128 {
     }
 }
 
-/// Specify kinds of interfaces.
-#[derive(Debug, Clone)]
-pub enum IfKind {
-    All,
-    IPv4,
-    IPv6,
-
-    /// By the interface name, for example "en0"
-    Name(String),
-
-    /// By the interface address, for example "192.168.0.1"
-    Addr(IpAddr),
-}
-
-impl IfKind {
-    /// Checks if `intf` matches with this interface kind.
-    pub fn matches(&self, intf: &Interface) -> bool {
-        match self {
-            IfKind::All => true,
-            IfKind::IPv4 => intf.ip().is_ipv4(),
-            IfKind::IPv6 => intf.ip().is_ipv6(),
-            _ => false,
-        }
-    }
-}
 #[cfg(test)]
 mod tests {
     use super::{decode_txt, encode_txt, u8_slice_to_hex, ServiceInfo, TxtProperty};

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -442,6 +442,7 @@ fn test_into_txt_properties() {
     assert_eq!(txt_props.get_property_val_str("key2").unwrap(), "val2");
 }
 
+/// Test enabling an interface using its name, for example "en0".
 #[test]
 fn service_with_named_interface_only() {
     // Create a daemon
@@ -506,6 +507,7 @@ fn service_with_named_interface_only() {
     let if_name = if_addrs[0].name.clone();
 
     // Enable the named interface.
+    println!("Enable interface with name {}", &if_name);
     d.enable_interface(IfKind::Name(if_name)).unwrap();
 
     // Browse again.

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -553,7 +553,7 @@ fn service_with_ipv4_only() {
 
     // Register a service with a name len > 15.
     let service_ipv4_only = "_test_ipv4_only._udp.local.";
-    let host_name = "my_host.";
+    let host_name = "my_host_ipv4_only.";
     let host_ipv4 = "";
     let port = 5201;
     let my_service = ServiceInfo::new(

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -234,7 +234,7 @@ fn service_without_properties_with_alter_net_v4() {
     let first_ip = if_addrs[0].ip();
     let alter_ip = ipv4_alter_net(&if_addrs);
     let host_ip = vec![first_ip, alter_ip];
-    let host_name = "serv-no-prop.";
+    let host_name = "serv-no-prop-v4.";
     let port = 5201;
     let my_service = ServiceInfo::new(
         ty_domain,
@@ -305,7 +305,7 @@ fn service_without_properties_with_alter_net_v6() {
     let first_ip = if_addrs[0].ip();
     let alter_ip = ipv6_alter_net(&if_addrs);
     let host_ip = vec![first_ip, alter_ip];
-    let host_name = "serv-no-prop.";
+    let host_name = "serv-no-prop-v6.";
     let port = 5201;
     let my_service = ServiceInfo::new(
         ty_domain,

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -508,7 +508,7 @@ fn service_with_named_interface_only() {
 
     // Enable the named interface.
     println!("Enable interface with name {}", &if_name);
-    d.enable_interface(IfKind::Name(if_name)).unwrap();
+    d.enable_interface(&if_name).unwrap();
 
     // Browse again.
     let browse_chan = d.browse(my_ty_domain).unwrap();


### PR DESCRIPTION
This diff tries to provide a common solution for two things: 

1. The existing PR #119 .
2. Disable IPv6 if desired:  issue #138 

The solution is to support a set of new methods of the daemon:  `enable_interface` and `disable_interface`.   By default, all available interface (except loopbacks) are enabled.  The user can call the new methods to select interfaces. 

