### PR TITLE
apply interface selections when IP addresses change

### DIFF
--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -908,7 +908,7 @@ impl Zeroconf {
             });
         }
 
-        self.apply_if_selections(my_ip_interfaces());
+        self.apply_intf_selections(my_ip_interfaces());
     }
 
     fn disable_interface(&mut self, kinds: Vec<IfKind>) {
@@ -919,7 +919,7 @@ impl Zeroconf {
             });
         }
 
-        self.apply_if_selections(my_ip_interfaces());
+        self.apply_intf_selections(my_ip_interfaces());
     }
 
     fn notify_monitors(&mut self, event: DaemonEvent) {
@@ -974,8 +974,8 @@ impl Zeroconf {
     /// Apply all selections to `interfaces`.
     ///
     /// For any interface, add it if selected but not bound yet,
-    /// delete it if not selected but already bound.
-    fn apply_if_selections(&mut self, interfaces: Vec<Interface>) {
+    /// delete it if not selected but still bound.
+    fn apply_intf_selections(&mut self, interfaces: Vec<Interface>) {
         // By default, we enable all interfaces.
         let intf_count = interfaces.len();
         let mut intf_selections = vec![true; intf_count];
@@ -1047,7 +1047,7 @@ impl Zeroconf {
         self.intf_socks.retain(|_, v| my_ifaddrs.contains(&v.intf));
 
         // Add newly found interfaces only if in our selections.
-        self.apply_if_selections(my_ifaddrs);
+        self.apply_intf_selections(my_ifaddrs);
     }
 
     fn add_new_interface(&mut self, intf: Interface) {

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -26,7 +26,10 @@ fn integration_success() {
     let ifaddrs_set: HashSet<_> = my_ip_interfaces().iter().map(|intf| intf.ip()).collect();
     let my_ifaddrs: Vec<_> = ifaddrs_set.into_iter().collect();
     let my_addrs_count = my_ifaddrs.len();
-    println!("My IP {} addr(s): {:?}", my_ifaddrs.len(), &my_ifaddrs);
+    println!("My IP {} addr(s):", my_ifaddrs.len());
+    for item in my_ifaddrs.iter() {
+        println!("{}", &item);
+    }
 
     let host_name = "my_host.";
     let port = 5200;
@@ -71,11 +74,13 @@ fn integration_success() {
                 ServiceEvent::ServiceResolved(info) => {
                     let addrs = info.get_addresses();
                     println!(
-                        "Resolved a new service: {} with {} addr(s): {:?}",
+                        "Resolved a new service: {} with {} addr(s)",
                         info.get_fullname(),
-                        addrs.len(),
-                        addrs
+                        addrs.len()
                     );
+                    for a in addrs.iter() {
+                        println!("{}", a);
+                    }
                     if info.get_fullname().contains(&instance_name) {
                         let mut num = resolve_count_clone.lock().unwrap();
                         *num += 1;


### PR DESCRIPTION
Currently when new IPs are found on the system, the interface selections are not applied. As the result, `disable_interface()` might stop working after IP addresses change on the host.