### PR TITLE
Always include subtype info if exists

### DIFF
--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1428,13 +1428,13 @@ impl Zeroconf {
 
         let mut info = ServiceInfo::new(ty_domain, &my_name, "", (), 0, None)?;
 
+        // Be sure setting `subtype` if available even when querying for the parent domain.
         if let Some(subtype) = self.cache.subtype.get(fullname) {
             debug!(
                 "ty_domain: {} found subtype {} for instance: {}",
                 ty_domain, subtype, fullname
             );
             if info.get_subtype().is_none() {
-                // Even when querying the parent domain, we include the subtype info.
                 info.set_subtype(subtype.clone());
             }
         }
@@ -1906,6 +1906,8 @@ impl DnsCache {
     fn add_or_update(&mut self, incoming: DnsRecordBox) -> Option<(&DnsRecordBox, bool)> {
         let entry_name = incoming.get_name().to_string();
 
+        // If it is PTR with subtype, store a mapping from the instance fullname
+        // to the subtype in this cache.
         if incoming.get_type() == TYPE_PTR {
             let (_, subtype_opt) = split_sub_domain(&entry_name);
             if let Some(subtype) = subtype_opt {

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -21,7 +21,11 @@ const DNS_OTHER_TTL: u32 = 4500; // 75 minutes for non-host records (PTR, TXT et
 #[derive(Debug, Clone)]
 pub struct ServiceInfo {
     ty_domain: String,          // <service>.<domain>
+
+    /// See RFC6763 section 7.1 about "Subtypes":
+    /// https://datatracker.ietf.org/doc/html/rfc6763#section-7.1
     sub_domain: Option<String>, // <subservice>._sub.<service>.<domain>
+
     fullname: String,           // <instance>.<service>.<domain>
     server: String,             // fully qualified name for service host
     addresses: HashSet<IpAddr>,

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -295,6 +295,10 @@ impl ServiceInfo {
             false
         }
     }
+
+    pub(crate) fn set_subtype(&mut self, subtype: String) {
+        self.sub_domain = Some(subtype);
+    }
 }
 
 /// This trait allows for parsing an input into a set of one or multiple [`Ipv4Addr`].

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -20,14 +20,14 @@ const DNS_OTHER_TTL: u32 = 4500; // 75 minutes for non-host records (PTR, TXT et
 /// as well as A (IPv4 Address) and AAAA (IPv6 Address) records.
 #[derive(Debug, Clone)]
 pub struct ServiceInfo {
-    ty_domain: String,          // <service>.<domain>
+    ty_domain: String, // <service>.<domain>
 
     /// See RFC6763 section 7.1 about "Subtypes":
     /// https://datatracker.ietf.org/doc/html/rfc6763#section-7.1
     sub_domain: Option<String>, // <subservice>._sub.<service>.<domain>
 
-    fullname: String,           // <instance>.<service>.<domain>
-    server: String,             // fully qualified name for service host
+    fullname: String, // <instance>.<service>.<domain>
+    server: String,   // fully qualified name for service host
     addresses: HashSet<IpAddr>,
     port: u16,
     host_ttl: u32,  // used for SRV and Address records

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -760,8 +760,13 @@ fn subtype() {
             match browse_chan.recv_timeout(timeout) {
                 Ok(event) => match event {
                     ServiceEvent::ServiceResolved(info) => {
-                        println!("Resolved a service of {}", &info.get_fullname());
+                        println!(
+                            "Resolved a service of {} subdomain {:?}",
+                            &info.get_fullname(),
+                            info.get_subtype()
+                        );
                         assert_eq!(fullname.as_str(), info.get_fullname());
+                        assert_eq!(subtype_domain, info.get_subtype().as_ref().unwrap());
                         break;
                     }
                     e => {


### PR DESCRIPTION
This is to fix issue #145 (partially it turns out ;-) )

Currently `ServiceInfo` only contains `sub_domain` info if the query targets the subtype. The `sub_domain` is `None` if it is generated for querying the parent service type.

Part of the reason is that we only store mappings from PTR to instance SRV, not the other way.  Both parent type PTR and subtype PTR points to the same instance SRV.  When querying the parent PTR, we wouldn't know about the subtype PTR from the instance SRV. This patch is to make the reverse lookup possible.