### PR TITLE
Update CI: replace actions-rs as it is deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,8 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v2
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.60.0
-          override: true
-          components: rustfmt, clippy
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.60.0
       - name: Run rustfmt and fail if any warnings
         run: cargo fmt -- --check
       - name: Build

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -23,7 +23,7 @@ pub struct ServiceInfo {
     ty_domain: String, // <service>.<domain>
 
     /// See RFC6763 section 7.1 about "Subtypes":
-    /// https://datatracker.ietf.org/doc/html/rfc6763#section-7.1
+    /// <https://datatracker.ietf.org/doc/html/rfc6763#section-7.1>
     sub_domain: Option<String>, // <subservice>._sub.<service>.<domain>
 
     fullname: String, // <instance>.<service>.<domain>


### PR DESCRIPTION
As mentioned in this: https://github.com/actions-rs/toolchain/issues/216 

