### PR TITLE
update flume to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ logging = ["log"]
 default = ["async", "logging"]
 
 [dependencies]
-flume = { version = "0.10", default-features = false } # channel between threads
+flume = { version = "0.11", default-features = false } # channel between threads
 if-addrs = { version = "0.10", features = ["link-local"] } # get local IP addresses
 log = { version = "0.4", optional = true }             # logging
 polling = "2.1"                                        # select/poll sockets


### PR DESCRIPTION
It's important for us to keep `flume` up to date.