### PR TITLE
signal event key is possible to overlap with socket poll ids

### DIFF
--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -428,9 +428,8 @@ impl ServiceDaemon {
             match zc.poller.wait(&mut events, timeout) {
                 Ok(_) => {
                     for ev in events.iter() {
+                        debug!("event received with key {}", ev.key);
                         if ev.key == signal_event_key {
-                            debug!("signal socket event received with key {}", ev.key);
-
                             // Drain signals as we will drain commands as well.
                             zc.signal_sock_drain();
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -378,7 +378,7 @@ impl ServiceDaemon {
     /// 5. process retransmissions if any.
     fn run(mut zc: Zeroconf, receiver: Receiver<Command>) -> Option<Command> {
         // Add the daemon's signal socket to the poller.
-        let signal_event_key = 7;
+        let signal_event_key = usize::MAX - 1; // avoid to overlap with zc.poll_ids
         if let Err(e) = zc
             .poller
             .add(&zc.signal_sock, polling::Event::readable(signal_event_key))

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -429,6 +429,8 @@ impl ServiceDaemon {
                 Ok(_) => {
                     for ev in events.iter() {
                         if ev.key == signal_event_key {
+                            debug!("signal socket event received with key {}", ev.key);
+
                             // Drain signals as we will drain commands as well.
                             zc.signal_sock_drain();
 


### PR DESCRIPTION
In a recent test, I noticed that the signal event key (hardcoded to 7) is possible to overlap with socket poll ids, and then causes the socket cannot be polled as we process signal event key first.

This patch is to change the signal event key to use `usize::MAX - 1` to avoid such overlapping.
 