### PR TITLE
Fix panic due to range out of bounds in txt record parsing

### DIFF
--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -642,7 +642,11 @@ fn decode_txt(txt: &[u8]) -> Vec<TxtProperty> {
         }
         offset += 1; // move over the length byte
 
-        let kv_bytes = &txt[offset..offset + length];
+        let offset_end = offset + length;
+        if offset_end > txt.len() {
+            break; // Would be out of range, skipping this property.
+        }
+        let kv_bytes = &txt[offset..offset_end];
 
         // split key and val using the first `=`
         let (k, v) = match kv_bytes.iter().position(|&x| x == b'=') {

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -866,9 +866,9 @@ mod tests {
         // Decode the record content
         let decoded = decode_txt(&encoded);
         // We expect the out of bounds length for the second property to have caused the rest of the record content to be skipped.
-        // Test that we only parsed the first record
+        // Test that we only parsed the first property.
         assert_eq!(decoded.len(), 1);
-        // Test that the record we parsed is key1
+        // Test that the key of the property we parsed is "key1"
         assert_eq!(decoded[0].key, "key1");
     }
 }


### PR DESCRIPTION
I noticed the following panic in my crash reporting earlier:

```
range end index 303 out of range for slice of length 288 (C:\...\src\service_info.rs:645:25)
```

I'm not entirely sure if this would be the correct solution, but I've made an attempt. 