### PR TITLE
netmask -> subnet

### DIFF
--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -713,11 +713,12 @@ pub(crate) fn valid_ip_on_intf(addr: &IpAddr, intf: &Interface) -> bool {
     }
 }
 
-/// Returns the netmask part of `addr` as `u128` for IPv4 and IPv6 address.
-pub(crate) fn ifaddr_netmask(addr: &IfAddr) -> u128 {
+/// Returns the bitwise and (&) of the netmask and ip parts of `addr` as `u128` for IPv4 and IPv6 address.
+/// Suitable for checking if two networks are on the same subnet.
+pub(crate) fn ifaddr_subnet(addr: &IfAddr) -> u128 {
     match addr {
-        IfAddr::V4(addrv4) => u32::from(addrv4.netmask) as u128,
-        IfAddr::V6(addrv6) => u128::from(addrv6.netmask),
+        IfAddr::V4(addrv4) => (u32::from(addrv4.netmask) & u32::from(addrv4.ip)) as u128,
+        IfAddr::V6(addrv6) => u128::from(addrv6.netmask) & u128::from(addrv6.ip),
     }
 }
 


### PR DESCRIPTION
Hi, fantastic library I am over the moon to be rid of my C dependency on libavahi-client!
However, I've experienced some pretty strange behavior - using two wired connections, I am only able to discover services on one of them at a time. Even more strangely, which wired connection is used is random for each invocation of the program! I think I've traced the source to this change
https://github.com/keepsimple1/mdns-sd/commit/545631a051def8805fa96d053a14ae5dadc3a295

It seems the intent was to not send multiple queries to the same subnet, but the implementation instead ended up excluding any networks that use the same netmask.

As an example, my two wired connections both have the netmask 255.255.255.0, but their ip addresses and therefore subnets are completely different. Since the interfaces are stored in a hashmap, this lead to some rather strange behavior in which the order of iteration of the hashmap (which is random for each invocation of the hashmap) determined which interface was allowed to be used.

The fix seems pretty simple - get the subnet of the interface by a bitwise & of the address and the netmask and use this to check if we've already sent on that subnet.

Again, thanks for the library :)