### PR TITLE
fine-tune MAX_MSG_ABSOLUTE

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -32,7 +32,9 @@ pub(crate) const CLASS_IN: u16 = 1;
 pub(crate) const CLASS_MASK: u16 = 0x7FFF;
 pub(crate) const CLASS_UNIQUE: u16 = 0x8000;
 
-pub(crate) const MAX_MSG_ABSOLUTE: usize = 8966;
+/// Max size of UDP datagram payload: 9000 bytes - IP header 20 bytes - UDP header 8 bytes.
+/// Reference: RFC6762: https://datatracker.ietf.org/doc/html/rfc6762#section-17
+pub(crate) const MAX_MSG_ABSOLUTE: usize = 8972;
 
 // Definitions for DNS message header "flags" field
 //

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1386,6 +1386,13 @@ impl Zeroconf {
             None => return false,
         };
         let mut buf = vec![0u8; MAX_MSG_ABSOLUTE];
+
+        // Read the next mDNS UDP datagram.
+        //
+        // If the datagram is larger than `buf`, excess bytes may or may not
+        // be truncated by the socket layer depending on the platform's libc.
+        // In any case, such large datagram will not be decoded properly and
+        // this function should return false but should not crash.
         let sz = match intf_sock.sock.read(&mut buf) {
             Ok(sz) => sz,
             Err(e) => {


### PR DESCRIPTION
This is a follow-up patch for issue #168. 

- I forgot why the max size was set to 8966 exactly. Now set it based on 9000 bytes max datagram size minus headers.
- Also added comments for socket `read`.