### PR TITLE
refresh SRV records and send out ServiceRemoved for expired SRV

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Build
         run: cargo build
       - name: Run clippy and fail if any warnings
-        run: cargo clippy -- -W clippy::all -D warnings
+        run: cargo clippy -- -D warnings
       - name: Run tests
         run: cargo test

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -2435,7 +2435,7 @@ impl DnsCache {
                                 debug!("expired SRV: {}: {}", ty_domain, srv.get_name());
                                 expired_instances
                                     .entry(ty_domain.to_string())
-                                    .or_insert(HashSet::new())
+                                    .or_insert_with(HashSet::new)
                                     .insert(srv.get_name().to_string());
                             }
                             !expired
@@ -2457,7 +2457,7 @@ impl DnsCache {
                         debug!("expired PTR: {}: {}", ty_domain, dns_ptr.alias);
                         expired_instances
                             .entry(ty_domain.to_string())
-                            .or_insert(HashSet::new())
+                            .or_insert_with(HashSet::new)
                             .insert(dns_ptr.alias.clone());
                     }
                 }

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -302,6 +302,12 @@ impl ServiceInfo {
     pub(crate) fn set_subtype(&mut self, subtype: String) {
         self.sub_domain = Some(subtype);
     }
+
+    /// host_ttl is for SRV and address records
+    /// currently only used for testing.
+    pub(crate) fn _set_host_ttl(&mut self, ttl: u32) {
+        self.host_ttl = ttl;
+    }
 }
 
 /// Removes potentially duplicated ".local." at the end of "hostname".


### PR DESCRIPTION
This patch is to fix issue raised in #176.  There are two parts:

- [x] Add checks of refresh for SRV record so that they will be updated if the responder is alive.
- [x] Also triggers `ServiceRemoved` when SRV record expires as the responder is no longer active.

Added a new setter `_set_host_ttl()` for `DnsRecord` to support testing.

Also addressed issue #203 : only apply cache-flush bit if the record is new, i.e. rdata changed. Otherwise, it is only a refresh of TTL. This makes sense to me as it can avoid unnecessary new ServiceResolved events.

Also removed `-Wclippy::all` from CI as it refers the default warnings, hence is redundant with `-D warnings`.  (https://doc.rust-lang.org/clippy/) 