### PR TITLE
Do not consider port 0 as a missing info

### DIFF
--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -263,7 +263,6 @@ impl ServiceInfo {
         let some_missing = self.ty_domain.is_empty()
             || self.fullname.is_empty()
             || self.server.is_empty()
-            || self.port == 0
             || self.addresses.is_empty();
         !some_missing
     }


### PR DESCRIPTION
I was playing around with the library and comparing results with `avahi-browse` and `zeroconf` from python.
I found a service type `_device-info._tcp.local.` which does announce a port `0`. It's used by the Linux samba implantation to announce some additional information for Mac-OS based computers, but without an actual port, by setting the port to 0.

So the _device-info.tcp.local. is never resolved for me using mdns-sd.
This change should fix the issue.

I really like using this library. ❤️ 

If you need more information regarding this PR, please let me know.

