### PR TITLE
query TYPE_A and TYPE_AAAA via Command::Resolve

### DIFF
--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1571,6 +1571,12 @@ impl Zeroconf {
             }
         }
 
+        // if we have no A or AAAA records yet, try to query them if we have a hostname
+        if !info.get_hostname().is_empty() && info.get_addresses().is_empty() {
+            self.send_query(info.get_hostname(), TYPE_A);
+            self.send_query(info.get_hostname(), TYPE_AAAA);
+        }
+
         Ok(info)
     }
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1580,12 +1580,6 @@ impl Zeroconf {
             }
         }
 
-        // if we have no A or AAAA records yet, try to query them if we have a hostname
-        if !info.get_hostname().is_empty() && info.get_addresses().is_empty() {
-            self.send_query(info.get_hostname(), TYPE_A);
-            self.send_query(info.get_hostname(), TYPE_AAAA);
-        }
-
         Ok(info)
     }
 


### PR DESCRIPTION
This fixes issues with resolving records published by python-zeroconf or systemd-resolved without an actual A or AAAA address assigned.

Closes #182 



Manually tested on linux and windows successfully
