### PR TITLE
example code: refactor the query output prints and the register hostname

### DIFF
--- a/examples/query.rs
+++ b/examples/query.rs
@@ -36,14 +36,16 @@ fn main() {
         match event {
             ServiceEvent::ServiceResolved(info) => {
                 println!(
-                    "At {:?}: Resolved a new service: {} host: {} port: {} IP: {:?} TXT properties: {:?}",
+                    "At {:?}: Resolved a new service: {}\n host: {}\n port: {}\n IP: {:?}",
                     now.elapsed(),
                     info.get_fullname(),
                     info.get_hostname(),
                     info.get_port(),
                     info.get_addresses(),
-                    info.get_properties(),
                 );
+                for prop in info.get_properties().iter() {
+                    println!(" Property: {}", prop);
+                }
             }
             other_event => {
                 println!("At {:?} : {:?}", now.elapsed(), &other_event);

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -36,13 +36,15 @@ fn main() {
         match event {
             ServiceEvent::ServiceResolved(info) => {
                 println!(
-                    "At {:?}: Resolved a new service: {}\n host: {}\n port: {}\n IP: {:?}",
+                    "At {:?}: Resolved a new service: {}\n host: {}\n port: {}",
                     now.elapsed(),
                     info.get_fullname(),
                     info.get_hostname(),
                     info.get_port(),
-                    info.get_addresses(),
                 );
+                for addr in info.get_addresses().iter() {
+                    println!(" address: {}", addr);
+                }
                 for prop in info.get_properties().iter() {
                     println!(" Property: {}", prop);
                 }

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -43,7 +43,7 @@ fn main() {
                     info.get_port(),
                 );
                 for addr in info.get_addresses().iter() {
-                    println!(" address: {}", addr);
+                    println!(" Address: {}", addr);
                 }
                 for prop in info.get_properties().iter() {
                     println!(" Property: {}", prop);

--- a/examples/register.rs
+++ b/examples/register.rs
@@ -44,7 +44,7 @@ fn main() {
     // With `enable_addr_auto()`, we can give empty addrs and let the lib find them.
     // If the caller knows specific addrs to use, then assign the addrs here.
     let my_addrs = "";
-    let service_hostname = "mdns-example.local.";
+    let service_hostname = format!("{}{}", instance_name, &service_type);
     let port = 3456;
 
     // The key string in TXT properties is case insensitive. Only the first
@@ -55,7 +55,7 @@ fn main() {
     let service_info = ServiceInfo::new(
         &service_type,
         instance_name,
-        service_hostname,
+        &service_hostname,
         my_addrs,
         port,
         &properties[..],


### PR DESCRIPTION
Now the query output is nicer to read: 
```
$ cargo run --example query _printer._tcp 
<snip>
At 243.90251ms: Resolved a new service: Brother HL-L2390DW._printer._tcp.local.
 host: BRW485F99726515.local.
 port: 515
 Address: 192.168.0.111
 Address: fe80::4a5f:99ff:fe72:6515
 Property: txtvers=1
 Property: qtotal=1
 Property: pdl=application/octet-stream,image/urf,image/pwg-raster
 Property: rp=duerqxesz5090
 Property: note=
 Property: ty=Brother HL-L2390DW
 Property: product=(Brother HL-L2390DW)
 Property: adminurl=http://BRW485F99726515.local./
 Property: priority=50
 Property: usb_MFG=Brother
 Property: usb_MDL=HL-L2390DW
 Property: usb_CMD=PJL,HBP,URF
 Property: Color=F
 Property: Copies=T
 Property: Duplex=T
 Property: Fax=F
 Property: Scan=T
 Property: PaperCustom=T
 Property: Binary=T
 Property: Transparent=T
 Property: TBCP=F
 Property: UUID=e3248000-80ce-11db-8000-485f99726515
```