### PR TITLE
Implemented unicast responses to direct unicast, unicast questions and legacy unicast queries.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ if-addrs = { version = "0.10", features = ["link-local"] } # get local IP addres
 log = { version = "0.4", optional = true }             # logging
 polling = "2.1"                                        # select/poll sockets
 socket2 = { version = "0.5.5", features = ["all"] }      # socket APIs
+socket-pktinfo = { version = "0.2.1" }                  # socket packet info extension
 
 [dev-dependencies]
 fastrand = "1.8"

--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ This implementation is based on the following RFCs:
 
 This is still beta software. We focus on the common use cases at hand. And we tested with some existing common tools (e.g. `Avahi` on Linux, `dns-sd` on MacOS, and `Bonjour` library on iOS) to verify the basic compatibility.
 
-Currently this library has the following limitations:
-- Only support multicast, no unicast send/recv.
-
 ## License
 
 Licensed under either of

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -48,6 +48,7 @@ pub(crate) const MAX_MSG_ABSOLUTE: usize = 8972;
 pub(crate) const FLAGS_QR_MASK: u16 = 0x8000; // mask for query/response bit
 pub(crate) const FLAGS_QR_QUERY: u16 = 0x0000;
 pub(crate) const FLAGS_QR_RESPONSE: u16 = 0x8000;
+pub(crate) const FLAGS_UNICAST_RESPONSE_MASK: u16 = 0x8000; // mask for question unicast response bit
 pub(crate) const FLAGS_AA: u16 = 0x0400; // mask for Authoritative answer bit
 
 pub(crate) type DnsRecordBox = Box<dyn DnsRecordExt + Send>;
@@ -75,6 +76,12 @@ impl DnsEntry {
 #[derive(Debug)]
 pub(crate) struct DnsQuestion {
     pub(crate) entry: DnsEntry,
+}
+
+impl DnsQuestion {
+    pub fn is_unicast_response_requested(&self) -> bool {
+        self.entry.class & FLAGS_UNICAST_RESPONSE_MASK == FLAGS_UNICAST_RESPONSE_MASK
+    }
 }
 
 /// A DNS Resource Record - like a DNS entry, but has a TTL.


### PR DESCRIPTION
Draft for now as I now need to construct some tests for this to verify it functions as expected.

One missing area for now is the following from RFC 6762:

> When receiving a question with the unicast-response bit set, a
   responder SHOULD usually respond with a unicast packet directed back
   to the querier.  However, if the responder has not multicast that
   record recently (within one quarter of its TTL), then the responder
   SHOULD instead multicast the response so as to keep all the peer
   caches up to date, and to permit passive conflict detection.  In the
   case of answering a probe question ([Section 8.1](https://www.rfc-editor.org/rfc/rfc6762#section-8.1)) with the unicast-
   response bit set, the responder should always generate the requested
   unicast response, but it may also send a multicast announcement if
   the time since the last multicast announcement of that record is more
   than a quarter of its TTL.

Implementing the above will require storing the time in which each service record was last multicasted on each specific interface so is therefore quite complex. For now I have simply used the logic that if all the questions in a given query request a unicast response, a unicast response is sent.