### PR TITLE
Add support for resolving non-service hostnames

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,8 +131,8 @@ mod service_info;
 
 pub use error::{Error, Result};
 pub use service_daemon::{
-    DaemonEvent, DaemonStatus, IfKind, Metrics, ServiceDaemon, ServiceEvent, UnregisterStatus,
-    SERVICE_NAME_LEN_MAX_DEFAULT,
+    DaemonEvent, DaemonStatus, IfKind, Metrics, ResolutionEvent, ServiceDaemon, ServiceEvent,
+    UnregisterStatus, SERVICE_NAME_LEN_MAX_DEFAULT,
 };
 pub use service_info::{AsIpAddrs, IntoTxtProperties, ServiceInfo, TxtProperties, TxtProperty};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,8 +131,8 @@ mod service_info;
 
 pub use error::{Error, Result};
 pub use service_daemon::{
-    DaemonEvent, DaemonStatus, IfKind, Metrics, ResolutionEvent, ServiceDaemon, ServiceEvent,
-    UnregisterStatus, SERVICE_NAME_LEN_MAX_DEFAULT,
+    DaemonEvent, DaemonStatus, HostnameResolutionEvent, IfKind, Metrics, ServiceDaemon,
+    ServiceEvent, UnregisterStatus, SERVICE_NAME_LEN_MAX_DEFAULT,
 };
 pub use service_info::{AsIpAddrs, IntoTxtProperties, ServiceInfo, TxtProperties, TxtProperty};
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -611,7 +611,7 @@ impl ServiceDaemon {
                     call_hostname_resolution_listener(
                         &zc.hostname_resolvers,
                         hostname,
-                        HostnameResolutionEvent::HostnameAddressesRemoved(
+                        HostnameResolutionEvent::AddressesRemoved(
                             hostname.to_string(),
                             zc.cache.get_addresses_for_host(hostname),
                         ),
@@ -1122,7 +1122,6 @@ impl Zeroconf {
             my_services: HashMap::new(),
             cache: DnsCache::new(),
             hostname_resolvers: HashMap::new(),
-            // hostname_resolver_timeouts: HashMap::new(),
             service_queriers: HashMap::new(),
             retransmissions: Vec::new(),
             counters: HashMap::new(),
@@ -1723,7 +1722,7 @@ impl Zeroconf {
     ) {
         let addresses = self.cache.get_addresses_for_host(hostname);
         if !addresses.is_empty() {
-            match sender.send(HostnameResolutionEvent::HostnameAddressesFound(
+            match sender.send(HostnameResolutionEvent::AddressesFound(
                 hostname.to_string(),
                 addresses,
             )) {
@@ -1887,10 +1886,7 @@ impl Zeroconf {
                 call_hostname_resolution_listener(
                     &self.hostname_resolvers,
                     hostname,
-                    HostnameResolutionEvent::HostnameAddressesFound(
-                        hostname.to_string(),
-                        addresses,
-                    ),
+                    HostnameResolutionEvent::AddressesFound(hostname.to_string(), addresses),
                 )
             });
 
@@ -2156,9 +2152,9 @@ pub enum HostnameResolutionEvent {
     /// Started searching for the ip address of a hostname.
     SearchStarted(String),
     /// One or more addresses for a hostname has been found.
-    HostnameAddressesFound(String, HashSet<IpAddr>),
+    AddressesFound(String, HashSet<IpAddr>),
     /// One or more addresses for a hostname has been removed.
-    HostnameAddressesRemoved(String, HashSet<IpAddr>),
+    AddressesRemoved(String, HashSet<IpAddr>),
     /// The search for the ip address of a hostname has timed out.
     SearchTimeout(String),
     /// Stopped searching for the ip address of a hostname.

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -523,7 +523,7 @@ impl ServiceDaemon {
                 .hostname_resolvers
                 .clone()
                 .into_iter()
-                .filter(|(_, (_, timeout))| timeout.is_some_and(|t| now >= t))
+                .filter(|(_, (_, timeout))| timeout.map(|t| now >= t).unwrap_or(false))
                 .map(|(hostname, _)| hostname)
             {
                 log::debug!("hostname resolver timeout for {}", &hostname);

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -275,6 +275,7 @@ impl ServiceDaemon {
     /// this `register` function again. No need to call `unregister` first.
     pub fn register(&self, mut service_info: ServiceInfo) -> Result<()> {
         check_service_name(service_info.get_fullname())?;
+        check_hostname(service_info.get_hostname())?;
 
         if service_info.is_addr_auto() {
             for iface in my_ip_interfaces() {
@@ -2674,7 +2675,7 @@ mod tests {
         let d = ServiceDaemon::new().expect("Failed to create daemon");
 
         let service = "_test_inval_ptr._udp.local.";
-        let host_name = "my_host_tmp_invalidated_ptr.";
+        let host_name = "my_host_tmp_invalidated_ptr.local.";
         let intfs: Vec<_> = my_ip_interfaces();
         let intf_ips: Vec<_> = intfs.iter().map(|intf| intf.ip()).collect();
         let port = 5201;

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -2641,8 +2641,9 @@ mod tests {
         valid_instance_name, IntfSock, ServiceDaemon, ServiceEvent, ServiceInfo, GROUP_ADDR_V4,
         MDNS_PORT,
     };
-    use crate::dns_parser::{
-        DnsOutgoing, DnsPointer, CLASS_IN, FLAGS_AA, FLAGS_QR_RESPONSE, TYPE_PTR,
+    use crate::{
+        dns_parser::{DnsOutgoing, DnsPointer, CLASS_IN, FLAGS_AA, FLAGS_QR_RESPONSE, TYPE_PTR},
+        service_daemon::check_hostname,
     };
     use std::{net::SocketAddr, net::SocketAddrV4, time::Duration};
 
@@ -2666,6 +2667,31 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             println!("{}", e);
+        }
+    }
+
+    #[test]
+    fn test_check_hostname() {
+        // valid hostnames
+        for hostname in &[
+            "my_host.local.",
+            &("A".repeat(255 - ".local.".len()) + ".local."),
+        ] {
+            let result = check_hostname(hostname);
+            assert!(result.is_ok());
+        }
+
+        // erroneous hostnames
+        for hostname in &[
+            "my_host.local",
+            ".local.",
+            &("A".repeat(256 - ".local.".len()) + ".local."),
+        ] {
+            let result = check_hostname(hostname);
+            assert!(result.is_err());
+            if let Err(e) = result {
+                println!("{}", e);
+            }
         }
     }
 

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1078,7 +1078,7 @@ fn test_hostname_resolution() {
     let event_receiver = d.resolve_hostname(hostname, Some(2000)).unwrap();
     let resolved = loop {
         match event_receiver.recv() {
-            Ok(HostnameResolutionEvent::HostnameAddressesFound(found_hostname, addresses)) => {
+            Ok(HostnameResolutionEvent::AddressesFound(found_hostname, addresses)) => {
                 assert!(found_hostname == hostname);
                 assert!(addresses.contains(&service_ip_addr));
                 break true;
@@ -1106,7 +1106,7 @@ fn hostname_resolution_timeout() {
     let event_receiver = d.resolve_hostname(hostname, Some(2000)).unwrap();
     let resolved = loop {
         match event_receiver.recv() {
-            Ok(HostnameResolutionEvent::HostnameAddressesFound(found_hostname, _addresses)) => {
+            Ok(HostnameResolutionEvent::AddressesFound(found_hostname, _addresses)) => {
                 assert!(found_hostname == hostname);
                 break true;
             }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -31,7 +31,7 @@ fn integration_success() {
         println!("{}", &item);
     }
 
-    let host_name = "my_host.";
+    let host_name = "my_host.local.";
     let port = 5200;
     let mut properties = HashMap::new();
     properties.insert("property_1".to_string(), "test".to_string());
@@ -238,7 +238,7 @@ fn service_without_properties_with_alter_net_v4() {
     let first_ip = if_addrs[0].ip();
     let alter_ip = ipv4_alter_net(&if_addrs);
     let host_ip = vec![first_ip, alter_ip];
-    let host_name = "serv-no-prop-v4.";
+    let host_name = "serv-no-prop-v4.local.";
     let port = 5201;
     let my_service = ServiceInfo::new(
         ty_domain,
@@ -308,7 +308,7 @@ fn service_without_properties_with_alter_net_v6() {
     let first_ip = if_addrs[0].ip();
     let alter_ip = ipv6_alter_net(&if_addrs);
     let host_ip = vec![first_ip, alter_ip];
-    let host_name = "serv-no-prop-v6.";
+    let host_name = "serv-no-prop-v6.local.";
     let port = 5201;
     let my_service = ServiceInfo::new(
         ty_domain,
@@ -375,7 +375,7 @@ fn service_txt_properties_case_insensitive() {
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
     let instance_name = now.as_micros().to_string(); // Create a unique name.
-    let host_name = "properties_host.";
+    let host_name = "properties_host.local.";
     let port = 5201;
     let properties = [
         ("prop_CAP_CASE", "one"),
@@ -458,7 +458,7 @@ fn service_with_named_interface_only() {
 
     // Register a service with a name len > 15.
     let my_ty_domain = "_named_intf_only._udp.local.";
-    let host_name = "my_host.";
+    let host_name = "my_host.local.";
     let host_ipv4 = "";
     let port = 5202;
     let my_service = ServiceInfo::new(
@@ -548,7 +548,7 @@ fn service_with_ipv4_only() {
 
     // Register a service with a name len > 15.
     let service_ipv4_only = "_test_ipv4_only._udp.local.";
-    let host_name = "my_host_ipv4_only.";
+    let host_name = "my_host_ipv4_only.local.";
     let host_ipv4 = "";
     let port = 5201;
     let my_service = ServiceInfo::new(
@@ -611,7 +611,7 @@ fn service_with_invalid_addr_v4() {
         .filter(|iface| iface.addr.ip().is_ipv4())
         .collect();
     let alter_ip = ipv4_alter_net(&if_addrs);
-    let host_name = "my_host.";
+    let host_name = "my_host.local.";
     let port = 5201;
     let my_service = ServiceInfo::new(ty_domain, &instance_name, host_name, alter_ip, port, None)
         .expect("valid service info");
@@ -668,7 +668,7 @@ fn service_with_invalid_addr_v6() {
         .filter(|iface| iface.addr.ip().is_ipv6())
         .collect();
     let alter_ip = ipv6_alter_net(&if_addrs);
-    let host_name = "my_host.";
+    let host_name = "my_host.local.";
     let port = 5201;
     let my_service = ServiceInfo::new(ty_domain, &instance_name, host_name, alter_ip, port, None)
         .expect("valid service info");
@@ -722,7 +722,7 @@ fn subtype() {
         .unwrap();
     let instance_name = now.as_micros().to_string(); // Create a unique name.
     let host_ipv4 = my_ip_interfaces()[0].ip().to_string();
-    let host_name = "my_host.";
+    let host_name = "my_host.local.";
     let port = 5201;
     let my_service = ServiceInfo::new(
         subtype_domain,
@@ -777,7 +777,7 @@ fn service_name_check() {
     // Register a service with a name len > 15.
     let service_name_too_long = "_service-name-too-long._udp.local.";
     let host_ipv4 = "";
-    let host_name = "my_host.";
+    let host_name = "my_host.local.";
     let port = 5200;
     let my_service = ServiceInfo::new(
         service_name_too_long,
@@ -829,7 +829,7 @@ fn service_new_publish_after_browser() {
     let service_info = ServiceInfo::new(
         "_new-pub._udp.local.",
         "test1",
-        "my_host.",
+        "my_host.local.",
         "",
         1234,
         &txt_properties[..],
@@ -884,7 +884,7 @@ fn instance_name_two_dots() {
     let service_type = "_two-dots._udp.local.";
     let instance_name = "my_instance.";
     let host_ipv4 = "";
-    let host_name = "my_host.";
+    let host_name = "my_host.local.";
     let port = 5200;
     let my_service = ServiceInfo::new(
         service_type,


### PR DESCRIPTION
Resolves #191.

This adds several pieces of public API, for resolving mDNS hostnames as standalone.

- `ServiceDaemon::resolve(&self, hostname: &str) -> Result<Receiver<ResolutionEvent>>`
- `ServiceDaemon::stop_resolve(&self, hostname: &str) -> Result<()>`

as well as

```rust
pub enum ResolutionEvent {
    /// Started searching for the ip address of a hostname.
    SearchStarted(String),
    /// One or more addresses for a hostname has been found.
    HostnameAddressesFound(String, HashSet<IpAddr>),
    /// One or more addresses for a hostname has been removed.
    HostnameAddressesRemoved(String, HashSet<IpAddr>),
    /// Stopped searching for the ip address of a hostname.
    SearchStopped(String),
}
```

The internal implementation uses the dns cache for addresses, which *should* make it possible for service discovery and hostname discovery to benefit from each other in the case that you are running both at the same time.

The rest of the implementation is largely either copy paste of- or merging with the code that handles the service discovery, with some exceptions where the events are reporting an aggregate of ip-addresses rather than reporting one at a time.

### Other notes

I refactored `DnsCache::evict_expired` to resolve some borrow checker issues. The current implementation will evict all expired records before it starts sending out events. It should not have any effect on any users of `ServiceDaemon::browse`, since they don't have direct access to the cache.

The current implementation is a bit loud, because it's missing [Known Answer Suppression (RFC6762, sec. 7.1)](https://datatracker.ietf.org/doc/html/rfc6762#section-7.1) (which is stated as a MUST requirement). As far as I understand, the current implementation for service browsing does not have this either, so I think it should be considered as a new issue.