### PR TITLE
fix a test waiting for IPv6 addr

### DIFF
--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -345,6 +345,9 @@ fn service_without_properties_with_alter_net_v6() {
                             .iter()
                             .filter(|a| a.is_ipv6())
                             .collect();
+                        if addrs.is_empty() {
+                            continue; // In case IPv4 addr received first.
+                        }
                         assert_eq!(addrs.len(), 1); // first_ipv6 but no alter_ipv.
                         found = true;
                         break;


### PR DESCRIPTION
The latest main branch CI test is not stable on Windows: 

Run: https://github.com/keepsimple1/mdns-sd/actions/runs/8678439543/job/23795359546 

Error:
```
---- service_without_properties_with_alter_net_v6 stdout ----
Registered service with host_ip: [fe80::f9d5:d80:1f67:7226, ff:1:1:1:1:1:1:1]
Received event SearchStarted("_serv-no-prop._tcp.local. on addrs [10.1.0.64, fe80::f9d5:d80:1f67:7226, fe80::4ba1:7266:e46e:c2dc, 172.29.80.1]")
Received event ServiceFound("_serv-no-prop._tcp.local.", "1713070959023708._serv-no-prop._tcp.local.")
Resolved a service of 1713070959023708._serv-no-prop._tcp.local. addr(s): {10.1.0.[64](https://github.com/keepsimple1/mdns-sd/actions/runs/8678439543/job/23795359546#step:7:65)}
thread 'service_without_properties_with_alter_net_v6' panicked at 'assertion failed: `(left == right)`
  left: `0`,
 right: `1`', tests\mdns_test.rs:348:25
```

This patch is to make this test more stable and detect real issues if the test fails.
