### PR TITLE
Fix flaky test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ polling = "2.1"                                        # select/poll sockets
 socket2 = { version = "0.5.5", features = ["all"] }      # socket APIs
 
 [dev-dependencies]
-env_logger = "0.11.3"
+env_logger = { version = "= 0.10.2", default-features = false, features= ["humantime"] }
 fastrand = "1.8"
-test-log = "0.2.15"
+test-log = "= 0.2.14"
+test-log-macros = "= 0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,6 @@ polling = "2.1"                                        # select/poll sockets
 socket2 = { version = "0.5.5", features = ["all"] }      # socket APIs
 
 [dev-dependencies]
+env_logger = "0.11.3"
 fastrand = "1.8"
+test-log = "0.2.15"

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -8,6 +8,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::{Duration, SystemTime};
+use test_log::test;
 
 /// This test covers:
 /// register(announce), browse(query), response, unregister, shutdown.

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1066,7 +1066,7 @@ fn test_hostname_resolution() {
         .unwrap();
 
     let my_service = ServiceInfo::new(
-        "_test._tcp.local.",
+        "_host_res_test._tcp.local.",
         "my_instance",
         hostname,
         &[service_ip_addr] as &[IpAddr],


### PR DESCRIPTION
Seems like the `subtype` test has become flaky, after I accidentally named the service equally for the hostname resolution test from #192. This PR fixes that, as well as adding some dependencies for capturing output logs made by the `log` macros.