### PR TITLE
feat: apply nursery lints

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Build
         run: cargo build
       - name: Run clippy and fail if any warnings
-        run: cargo clippy -- -W clippy::all -W clippy::nursery -D warnings
+        run: cargo clippy -- -W clippy::all -D warnings
       - name: Run tests
         run: cargo test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Build
         run: cargo build
       - name: Run clippy and fail if any warnings
-        run: cargo clippy -- -D warnings
+        run: cargo clippy -- -W clippy::all -W clippy::nursery -D warnings
       - name: Run tests
         run: cargo test

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -638,10 +638,7 @@ impl DnsOutPacket {
                     // println!("set offset {} for {}", self.size, remaining);
 
                     // Find the current label to write into the packet
-                    let stop = match remaining.find('.') {
-                        Some(i) => here + i,
-                        None => end,
-                    };
+                    let stop = remaining.find('.').map_or(end, |i| here + i);
                     let label = &name[here..stop];
                     self.write_utf8(label);
 

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -134,7 +134,7 @@ impl DnsRecord {
         cmp::max(0, remaining_millis / 1000) as u32
     }
 
-    fn reset_ttl(&mut self, other: &DnsRecord) {
+    fn reset_ttl(&mut self, other: &Self) {
         self.ttl = other.ttl;
         self.created = other.created;
         self.refresh = get_expiration_time(self.created, self.ttl, 80);
@@ -219,7 +219,7 @@ impl DnsRecordExt for DnsAddress {
     }
 
     fn matches(&self, other: &dyn DnsRecordExt) -> bool {
-        if let Some(other_a) = other.any().downcast_ref::<DnsAddress>() {
+        if let Some(other_a) = other.any().downcast_ref::<Self>() {
             return self.address == other_a.address && self.record.entry == other_a.record.entry;
         }
         false
@@ -258,7 +258,7 @@ impl DnsRecordExt for DnsPointer {
     }
 
     fn matches(&self, other: &dyn DnsRecordExt) -> bool {
-        if let Some(other_ptr) = other.any().downcast_ref::<DnsPointer>() {
+        if let Some(other_ptr) = other.any().downcast_ref::<Self>() {
             return self.alias == other_ptr.alias && self.record.entry == other_ptr.record.entry;
         }
         false
@@ -319,7 +319,7 @@ impl DnsRecordExt for DnsSrv {
     }
 
     fn matches(&self, other: &dyn DnsRecordExt) -> bool {
-        if let Some(other_svc) = other.any().downcast_ref::<DnsSrv>() {
+        if let Some(other_svc) = other.any().downcast_ref::<Self>() {
             return self.host == other_svc.host
                 && self.port == other_svc.port
                 && self.weight == other_svc.weight
@@ -374,7 +374,7 @@ impl DnsRecordExt for DnsTxt {
     }
 
     fn matches(&self, other: &dyn DnsRecordExt) -> bool {
-        if let Some(other_txt) = other.any().downcast_ref::<DnsTxt>() {
+        if let Some(other_txt) = other.any().downcast_ref::<Self>() {
             return self.text == other_txt.text && self.record.entry == other_txt.record.entry;
         }
         false
@@ -416,7 +416,7 @@ impl DnsRecordExt for DnsHostInfo {
     }
 
     fn matches(&self, other: &dyn DnsRecordExt) -> bool {
-        if let Some(other_hinfo) = other.any().downcast_ref::<DnsHostInfo>() {
+        if let Some(other_hinfo) = other.any().downcast_ref::<Self>() {
             return self.cpu == other_hinfo.cpu
                 && self.os == other_hinfo.os
                 && self.record.entry == other_hinfo.record.entry;
@@ -495,7 +495,7 @@ impl DnsRecordExt for DnsNSec {
     }
 
     fn matches(&self, other: &dyn DnsRecordExt) -> bool {
-        if let Some(other_record) = other.any().downcast_ref::<DnsNSec>() {
+        if let Some(other_record) = other.any().downcast_ref::<Self>() {
             return self.next_domain == other_record.next_domain
                 && self.type_bitmap == other_record.type_bitmap
                 && self.record.entry == other_record.record.entry;
@@ -696,7 +696,7 @@ pub struct DnsOutgoing {
 
 impl DnsOutgoing {
     pub(crate) fn new(flags: u16) -> Self {
-        DnsOutgoing {
+        Self {
             flags,
             id: 0,
             multicast: true,

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -510,7 +510,7 @@ enum PacketState {
     Finished = 1,
 }
 
-pub(crate) struct DnsOutPacket {
+pub struct DnsOutPacket {
     pub(crate) data: Vec<Vec<u8>>,
     size: usize,
     state: PacketState,

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -144,7 +144,7 @@ impl DnsRecord {
         self.expires = expire_at;
     }
 
-    fn reset_ttl(&mut self, other: &DnsRecord) {
+    fn reset_ttl(&mut self, other: &Self) {
         self.ttl = other.ttl;
         self.created = other.created;
         self.refresh = get_expiration_time(self.created, self.ttl, 80);

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -19,23 +19,23 @@ use std::{
     time::SystemTime,
 };
 
-pub(crate) const TYPE_A: u16 = 1; // IPv4 address
-pub(crate) const TYPE_CNAME: u16 = 5;
-pub(crate) const TYPE_PTR: u16 = 12;
-pub(crate) const TYPE_HINFO: u16 = 13;
-pub(crate) const TYPE_TXT: u16 = 16;
-pub(crate) const TYPE_AAAA: u16 = 28; // IPv6 address
-pub(crate) const TYPE_SRV: u16 = 33;
-pub(crate) const TYPE_NSEC: u16 = 47; // Negative responses
-pub(crate) const TYPE_ANY: u16 = 255;
+pub const TYPE_A: u16 = 1; // IPv4 address
+pub const TYPE_CNAME: u16 = 5;
+pub const TYPE_PTR: u16 = 12;
+pub const TYPE_HINFO: u16 = 13;
+pub const TYPE_TXT: u16 = 16;
+pub const TYPE_AAAA: u16 = 28; // IPv6 address
+pub const TYPE_SRV: u16 = 33;
+pub const TYPE_NSEC: u16 = 47; // Negative responses
+pub const TYPE_ANY: u16 = 255;
 
-pub(crate) const CLASS_IN: u16 = 1;
-pub(crate) const CLASS_MASK: u16 = 0x7FFF;
-pub(crate) const CLASS_UNIQUE: u16 = 0x8000;
+pub const CLASS_IN: u16 = 1;
+pub const CLASS_MASK: u16 = 0x7FFF;
+pub const CLASS_UNIQUE: u16 = 0x8000;
 
 /// Max size of UDP datagram payload: 9000 bytes - IP header 20 bytes - UDP header 8 bytes.
 /// Reference: RFC6762: https://datatracker.ietf.org/doc/html/rfc6762#section-17
-pub(crate) const MAX_MSG_ABSOLUTE: usize = 8972;
+pub const MAX_MSG_ABSOLUTE: usize = 8972;
 
 // Definitions for DNS message header "flags" field
 //
@@ -45,15 +45,15 @@ pub(crate) const MAX_MSG_ABSOLUTE: usize = 8972;
 //   0  1  2  3  4  5  6  7  8  9  0  1  2  3  4  5
 // |QR|   Opcode  |AA|TC|RD|RA|   Z    |   RCODE   |
 //
-pub(crate) const FLAGS_QR_MASK: u16 = 0x8000; // mask for query/response bit
-pub(crate) const FLAGS_QR_QUERY: u16 = 0x0000;
-pub(crate) const FLAGS_QR_RESPONSE: u16 = 0x8000;
-pub(crate) const FLAGS_AA: u16 = 0x0400; // mask for Authoritative answer bit
+pub const FLAGS_QR_MASK: u16 = 0x8000; // mask for query/response bit
+pub const FLAGS_QR_QUERY: u16 = 0x0000;
+pub const FLAGS_QR_RESPONSE: u16 = 0x8000;
+pub const FLAGS_AA: u16 = 0x0400; // mask for Authoritative answer bit
 
-pub(crate) type DnsRecordBox = Box<dyn DnsRecordExt + Send>;
+pub type DnsRecordBox = Box<dyn DnsRecordExt + Send>;
 
 #[derive(PartialEq, Debug)]
-pub(crate) struct DnsEntry {
+pub struct DnsEntry {
     pub(crate) name: String, // always lower case.
     pub(crate) ty: u16,
     class: u16,
@@ -73,7 +73,7 @@ impl DnsEntry {
 
 /// A DNS question entry
 #[derive(Debug)]
-pub(crate) struct DnsQuestion {
+pub struct DnsQuestion {
     pub(crate) entry: DnsEntry,
 }
 
@@ -81,7 +81,7 @@ pub(crate) struct DnsQuestion {
 /// RFC: https://www.rfc-editor.org/rfc/rfc1035#section-3.2.1
 ///      https://www.rfc-editor.org/rfc/rfc1035#section-4.1.3
 #[derive(Debug)]
-pub(crate) struct DnsRecord {
+pub struct DnsRecord {
     pub(crate) entry: DnsEntry,
     ttl: u32,     // in seconds, 0 means this record should not be cached
     created: u64, // UNIX time in millis
@@ -148,7 +148,7 @@ impl PartialEq for DnsRecord {
     }
 }
 
-pub(crate) trait DnsRecordExt: fmt::Debug {
+pub trait DnsRecordExt: fmt::Debug {
     fn get_record(&self) -> &DnsRecord;
     fn get_record_mut(&mut self) -> &mut DnsRecord;
     fn write(&self, packet: &mut DnsOutPacket);
@@ -186,7 +186,7 @@ pub(crate) trait DnsRecordExt: fmt::Debug {
 }
 
 #[derive(Debug)]
-pub(crate) struct DnsAddress {
+pub struct DnsAddress {
     pub(crate) record: DnsRecord,
     pub(crate) address: IpAddr,
 }
@@ -228,7 +228,7 @@ impl DnsRecordExt for DnsAddress {
 
 /// A DNS pointer record
 #[derive(Debug)]
-pub(crate) struct DnsPointer {
+pub struct DnsPointer {
     record: DnsRecord,
     pub(crate) alias: String, // the full name of Service Instance
 }
@@ -267,7 +267,7 @@ impl DnsRecordExt for DnsPointer {
 
 // In common cases, there is one and only one SRV record for a particular fullname.
 #[derive(Debug)]
-pub(crate) struct DnsSrv {
+pub struct DnsSrv {
     pub(crate) record: DnsRecord,
     pub(crate) priority: u16,
     // lower number means higher priority. Should be 0 in common cases.
@@ -343,7 +343,7 @@ impl DnsRecordExt for DnsSrv {
 //    6.4).  Everything after the first '=' character to the end of the
 //    string (including subsequent '=' characters, if any) is the value
 #[derive(Debug)]
-pub(crate) struct DnsTxt {
+pub struct DnsTxt {
     pub(crate) record: DnsRecord,
     pub(crate) text: Vec<u8>,
 }
@@ -431,7 +431,7 @@ impl DnsRecordExt for DnsHostInfo {
 /// and
 /// [RFC6762 section 6.1](https://datatracker.ietf.org/doc/html/rfc6762#section-6.1)
 #[derive(Debug)]
-pub(crate) struct DnsNSec {
+pub struct DnsNSec {
     record: DnsRecord,
     next_domain: String,
     type_bitmap: Vec<u8>,
@@ -684,7 +684,7 @@ impl DnsOutPacket {
 
 /// Representation of an outgoing packet. The actual encoded packet
 /// is [DnsOutPacket].
-pub(crate) struct DnsOutgoing {
+pub struct DnsOutgoing {
     flags: u16,
     pub(crate) id: u16,
     multicast: bool,
@@ -907,7 +907,7 @@ impl DnsOutgoing {
 }
 
 #[derive(Debug)]
-pub(crate) struct DnsIncoming {
+pub struct DnsIncoming {
     offset: usize,
     data: Vec<u8>,
     pub(crate) questions: Vec<DnsQuestion>,
@@ -1303,7 +1303,7 @@ impl DnsIncoming {
 }
 
 /// Returns UNIX time in millis
-pub(crate) fn current_time_millis() -> u64 {
+pub fn current_time_millis() -> u64 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .expect("failed to get current UNIX time")

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -135,7 +135,7 @@ impl DnsRecord {
     }
 
     /// Return the absolute time for this record being created
-    fn get_created(&self) -> u64 {
+    const fn get_created(&self) -> u64 {
         self.created
     }
 

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -52,7 +52,7 @@ pub const FLAGS_AA: u16 = 0x0400; // mask for Authoritative answer bit
 
 pub type DnsRecordBox = Box<dyn DnsRecordExt + Send>;
 
-#[derive(PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug)]
 pub struct DnsEntry {
     pub(crate) name: String, // always lower case.
     pub(crate) ty: u16,

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -61,7 +61,7 @@ pub(crate) struct DnsEntry {
 }
 
 impl DnsEntry {
-    fn new(name: String, ty: u16, class: u16) -> Self {
+    const fn new(name: String, ty: u16, class: u16) -> Self {
         Self {
             name,
             ty,
@@ -106,19 +106,19 @@ impl DnsRecord {
         }
     }
 
-    pub(crate) fn get_expire_time(&self) -> u64 {
+    pub(crate) const fn get_expire_time(&self) -> u64 {
         self.expires
     }
 
-    pub(crate) fn get_refresh_time(&self) -> u64 {
+    pub(crate) const fn get_refresh_time(&self) -> u64 {
         self.refresh
     }
 
-    pub(crate) fn is_expired(&self, now: u64) -> bool {
+    pub(crate) const fn is_expired(&self, now: u64) -> bool {
         now >= self.expires
     }
 
-    pub(crate) fn refresh_due(&self, now: u64) -> bool {
+    pub(crate) const fn refresh_due(&self, now: u64) -> bool {
         now >= self.refresh
     }
 
@@ -707,11 +707,11 @@ impl DnsOutgoing {
         }
     }
 
-    pub(crate) fn is_query(&self) -> bool {
+    pub(crate) const fn is_query(&self) -> bool {
         (self.flags & FLAGS_QR_MASK) == FLAGS_QR_QUERY
     }
 
-    fn _is_response(&self) -> bool {
+    const fn _is_response(&self) -> bool {
         (self.flags & FLAGS_QR_MASK) == FLAGS_QR_RESPONSE
     }
 
@@ -945,11 +945,11 @@ impl DnsIncoming {
         Ok(incoming)
     }
 
-    pub(crate) fn is_query(&self) -> bool {
+    pub(crate) const fn is_query(&self) -> bool {
         (self.flags & FLAGS_QR_MASK) == FLAGS_QR_QUERY
     }
 
-    pub(crate) fn is_response(&self) -> bool {
+    pub(crate) const fn is_response(&self) -> bool {
         (self.flags & FLAGS_QR_MASK) == FLAGS_QR_RESPONSE
     }
 
@@ -1310,19 +1310,19 @@ pub(crate) fn current_time_millis() -> u64 {
         .as_millis() as u64
 }
 
-fn u16_from_be_slice(bytes: &[u8]) -> u16 {
+const fn u16_from_be_slice(bytes: &[u8]) -> u16 {
     let u8_array: [u8; 2] = [bytes[0], bytes[1]];
     u16::from_be_bytes(u8_array)
 }
 
-fn u32_from_be_slice(s: &[u8]) -> u32 {
+const fn u32_from_be_slice(s: &[u8]) -> u32 {
     let u8_array: [u8; 4] = [s[0], s[1], s[2], s[3]];
     u32::from_be_bytes(u8_array)
 }
 
 /// Returns the time in millis at which this record will have expired
 /// by a certain percentage.
-fn get_expiration_time(created: u64, ttl: u32, percent: u32) -> u64 {
+const fn get_expiration_time(created: u64, ttl: u32, percent: u32) -> u64 {
     created + (ttl * percent * 10) as u64
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,9 +17,9 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Msg(s) => write!(f, "{}", s),
-            Error::ParseIpAddr(s) => write!(f, "parsing of ip addr failed, reason: {}", s),
-            Error::Again => write!(f, "try again"),
+            Self::Msg(s) => write!(f, "{}", s),
+            Self::ParseIpAddr(s) => write!(f, "parsing of ip addr failed, reason: {}", s),
+            Self::Again => write!(f, "try again"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,7 @@ mod log {
 
 mod dns_parser;
 mod error;
+#[allow(clippy::cognitive_complexity)]
 mod service_daemon;
 mod service_info;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,6 @@ mod log {
 
 mod dns_parser;
 mod error;
-#[allow(clippy::cognitive_complexity)]
 mod service_daemon;
 mod service_info;
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -112,14 +112,14 @@ enum Counter {
 impl fmt::Display for Counter {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Counter::Register => write!(f, "register"),
-            Counter::RegisterResend => write!(f, "register-resend"),
-            Counter::Unregister => write!(f, "unregister"),
-            Counter::UnregisterResend => write!(f, "unregister-resend"),
-            Counter::Browse => write!(f, "browse"),
-            Counter::ResolveHostname => write!(f, "resolve-hostname"),
-            Counter::Respond => write!(f, "respond"),
-            Counter::CacheRefreshQuery => write!(f, "cache-refresh"),
+            Self::Register => write!(f, "register"),
+            Self::RegisterResend => write!(f, "register-resend"),
+            Self::Unregister => write!(f, "unregister"),
+            Self::UnregisterResend => write!(f, "unregister-resend"),
+            Self::Browse => write!(f, "browse"),
+            Self::ResolveHostname => write!(f, "resolve-hostname"),
+            Self::Respond => write!(f, "respond"),
+            Self::CacheRefreshQuery => write!(f, "cache-refresh"),
         }
     }
 }
@@ -960,11 +960,11 @@ impl IfKind {
     /// Checks if `intf` matches with this interface kind.
     fn matches(&self, intf: &Interface) -> bool {
         match self {
-            IfKind::All => true,
-            IfKind::IPv4 => intf.ip().is_ipv4(),
-            IfKind::IPv6 => intf.ip().is_ipv6(),
-            IfKind::Name(ifname) => ifname == &intf.name,
-            IfKind::Addr(addr) => addr == &intf.ip(),
+            Self::All => true,
+            Self::IPv4 => intf.ip().is_ipv4(),
+            Self::IPv6 => intf.ip().is_ipv6(),
+            Self::Name(ifname) => ifname == &intf.name,
+            Self::Addr(addr) => addr == &intf.ip(),
         }
     }
 }
@@ -972,21 +972,21 @@ impl IfKind {
 /// The first use case of specifying an interface was to
 /// use an interface name. Hence adding this for ergonomic reasons.
 impl From<&str> for IfKind {
-    fn from(val: &str) -> IfKind {
-        IfKind::Name(val.to_string())
+    fn from(val: &str) -> Self {
+        Self::Name(val.to_string())
     }
 }
 
 impl From<&String> for IfKind {
-    fn from(val: &String) -> IfKind {
-        IfKind::Name(val.to_string())
+    fn from(val: &String) -> Self {
+        Self::Name(val.to_string())
     }
 }
 
 /// Still for ergonomic reasons.
 impl From<IpAddr> for IfKind {
-    fn from(val: IpAddr) -> IfKind {
-        IfKind::Addr(val)
+    fn from(val: IpAddr) -> Self {
+        Self::Addr(val)
     }
 }
 
@@ -2242,20 +2242,20 @@ enum Command {
 impl fmt::Display for Command {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Command::Browse(_, _, _) => write!(f, "Command Browse"),
-            Command::ResolveHostname(_, _, _, _) => write!(f, "Command ResolveHostname"),
-            Command::Exit(_) => write!(f, "Command Exit"),
-            Command::GetStatus(_) => write!(f, "Command GetStatus"),
-            Command::GetMetrics(_) => write!(f, "Command GetMetrics"),
-            Command::Monitor(_) => write!(f, "Command Monitor"),
-            Command::Register(_) => write!(f, "Command Register"),
-            Command::RegisterResend(_) => write!(f, "Command RegisterResend"),
-            Command::SetOption(_) => write!(f, "Command SetOption"),
-            Command::StopBrowse(_) => write!(f, "Command StopBrowse"),
-            Command::StopResolveHostname(_) => write!(f, "Command StopResolveHostname"),
-            Command::Unregister(_, _) => write!(f, "Command Unregister"),
-            Command::UnregisterResend(_, _) => write!(f, "Command UnregisterResend"),
-            Command::Resolve(_, _) => write!(f, "Command Resolve"),
+            Self::Browse(_, _, _) => write!(f, "Command Browse"),
+            Self::ResolveHostname(_, _, _, _) => write!(f, "Command ResolveHostname"),
+            Self::Exit(_) => write!(f, "Command Exit"),
+            Self::GetStatus(_) => write!(f, "Command GetStatus"),
+            Self::GetMetrics(_) => write!(f, "Command GetMetrics"),
+            Self::Monitor(_) => write!(f, "Command Monitor"),
+            Self::Register(_) => write!(f, "Command Register"),
+            Self::RegisterResend(_) => write!(f, "Command RegisterResend"),
+            Self::SetOption(_) => write!(f, "Command SetOption"),
+            Self::StopBrowse(_) => write!(f, "Command StopBrowse"),
+            Self::StopResolveHostname(_) => write!(f, "Command StopResolveHostname"),
+            Self::Unregister(_, _) => write!(f, "Command Unregister"),
+            Self::UnregisterResend(_, _) => write!(f, "Command UnregisterResend"),
+            Self::Resolve(_, _) => write!(f, "Command Resolve"),
         }
     }
 }

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -486,7 +486,7 @@ where
     V: ToString,
 {
     fn from(prop: &(K, V)) -> Self {
-        TxtProperty {
+        Self {
             key: prop.0.to_string(),
             val: Some(prop.1.to_string().into_bytes()),
         }
@@ -499,7 +499,7 @@ where
     V: AsRef<[u8]>,
 {
     fn from(prop: (K, V)) -> Self {
-        TxtProperty {
+        Self {
             key: prop.0.to_string(),
             val: Some(prop.1.as_ref().into()),
         }
@@ -509,7 +509,7 @@ where
 /// Support a property that has no value.
 impl From<&str> for TxtProperty {
     fn from(key: &str) -> Self {
-        TxtProperty {
+        Self {
             key: key.to_string(),
             val: None,
         }

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -134,7 +134,7 @@ impl ServiceInfo {
 
     /// Returns if the service's addresses will be updated
     /// automatically when the host IP addrs change.
-    pub fn is_addr_auto(&self) -> bool {
+    pub const fn is_addr_auto(&self) -> bool {
         self.addr_auto
     }
 
@@ -151,7 +151,7 @@ impl ServiceInfo {
     ///
     /// For example: "_printer._sub._http._tcp.local.".
     #[inline]
-    pub fn get_subtype(&self) -> &Option<String> {
+    pub const fn get_subtype(&self) -> &Option<String> {
         &self.sub_domain
     }
 
@@ -165,7 +165,7 @@ impl ServiceInfo {
 
     /// Returns the properties from TXT records.
     #[inline]
-    pub fn get_properties(&self) -> &TxtProperties {
+    pub const fn get_properties(&self) -> &TxtProperties {
         &self.txt_properties
     }
 
@@ -201,13 +201,13 @@ impl ServiceInfo {
 
     /// Returns the service's port.
     #[inline]
-    pub fn get_port(&self) -> u16 {
+    pub const fn get_port(&self) -> u16 {
         self.port
     }
 
     /// Returns the service's addresses
     #[inline]
-    pub fn get_addresses(&self) -> &HashSet<IpAddr> {
+    pub const fn get_addresses(&self) -> &HashSet<IpAddr> {
         &self.addresses
     }
 
@@ -226,25 +226,25 @@ impl ServiceInfo {
 
     /// Returns the service's TTL used for SRV and Address records.
     #[inline]
-    pub fn get_host_ttl(&self) -> u32 {
+    pub const fn get_host_ttl(&self) -> u32 {
         self.host_ttl
     }
 
     /// Returns the service's TTL used for PTR and TXT records.
     #[inline]
-    pub fn get_other_ttl(&self) -> u32 {
+    pub const fn get_other_ttl(&self) -> u32 {
         self.other_ttl
     }
 
     /// Returns the service's priority used in SRV records.
     #[inline]
-    pub fn get_priority(&self) -> u16 {
+    pub const fn get_priority(&self) -> u16 {
         self.priority
     }
 
     /// Returns the service's weight used in SRV records.
     #[inline]
-    pub fn get_weight(&self) -> u16 {
+    pub const fn get_weight(&self) -> u16 {
         self.weight
     }
 

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -127,7 +127,7 @@ impl ServiceInfo {
     /// Indicates that the library should automatically
     /// update the addresses of this service, when IP
     /// address(es) are added or removed on the host.
-    pub fn enable_addr_auto(mut self) -> Self {
+    pub const fn enable_addr_auto(mut self) -> Self {
         self.addr_auto = true;
         self
     }

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -694,7 +694,7 @@ fn decode_txt_unique(txt: &[u8]) -> Vec<TxtProperty> {
 }
 
 /// Returns a tuple of (service_type_domain, optional_sub_domain)
-pub(crate) fn split_sub_domain(domain: &str) -> (&str, Option<&str>) {
+pub fn split_sub_domain(domain: &str) -> (&str, Option<&str>) {
     if let Some((_, ty_domain)) = domain.rsplit_once("._sub.") {
         (ty_domain, Some(domain))
     } else {
@@ -703,7 +703,7 @@ pub(crate) fn split_sub_domain(domain: &str) -> (&str, Option<&str>) {
 }
 
 /// Returns true if `addr` is in the same network of `intf`.
-pub(crate) fn valid_ip_on_intf(addr: &IpAddr, intf: &Interface) -> bool {
+pub fn valid_ip_on_intf(addr: &IpAddr, intf: &Interface) -> bool {
     match (addr, &intf.addr) {
         (IpAddr::V4(addr), IfAddr::V4(intf)) => {
             let netmask = u32::from(intf.netmask);
@@ -723,7 +723,7 @@ pub(crate) fn valid_ip_on_intf(addr: &IpAddr, intf: &Interface) -> bool {
 
 /// Returns the bitwise and (&) of the netmask and ip parts of `addr` as `u128` for IPv4 and IPv6 address.
 /// Suitable for checking if two networks are on the same subnet.
-pub(crate) fn ifaddr_subnet(addr: &IfAddr) -> u128 {
+pub fn ifaddr_subnet(addr: &IfAddr) -> u128 {
     match addr {
         IfAddr::V4(addrv4) => (u32::from(addrv4.netmask) & u32::from(addrv4.ip)) as u128,
         IfAddr::V6(addrv6) => u128::from(addrv6.netmask) & u128::from(addrv6.ip),

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -472,7 +472,9 @@ impl TxtProperty {
 
     /// Returns the value of a property as str.
     pub fn val_str(&self) -> &str {
-        self.val.as_ref().map_or("", |v| std::str::from_utf8(&v[..]).unwrap_or_default())
+        self.val
+            .as_ref()
+            .map_or("", |v| std::str::from_utf8(&v[..]).unwrap_or_default())
     }
 }
 
@@ -524,9 +526,15 @@ impl fmt::Display for TxtProperty {
 /// - If self.var is not UTF-8, will output its bytes as in hex.
 impl fmt::Debug for TxtProperty {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let val_string = self.val.as_ref()
-            .map_or_else(|| "None".to_string(), |v| std::str::from_utf8(&v[..])
-            .map_or_else(|_| format!("Some({})", u8_slice_to_hex(&v[..])), |s| format!("Some(\"{}\")", s)));
+        let val_string = self.val.as_ref().map_or_else(
+            || "None".to_string(),
+            |v| {
+                std::str::from_utf8(&v[..]).map_or_else(
+                    |_| format!("Some({})", u8_slice_to_hex(&v[..])),
+                    |s| format!("Some(\"{}\")", s),
+                )
+            },
+        );
 
         write!(
             f,
@@ -576,7 +584,12 @@ impl IntoTxtProperties for HashMap<String, String> {
 /// Mainly for backward compatibility.
 impl IntoTxtProperties for Option<HashMap<String, String>> {
     fn into_txt_properties(self) -> TxtProperties {
-        self.map_or_else(|| TxtProperties { properties: Vec::new() }, |h| h.into_txt_properties())
+        self.map_or_else(
+            || TxtProperties {
+                properties: Vec::new(),
+            },
+            |h| h.into_txt_properties(),
+        )
     }
 }
 
@@ -646,9 +659,10 @@ fn decode_txt(txt: &[u8]) -> Vec<TxtProperty> {
         let kv_bytes = &txt[offset..offset_end];
 
         // split key and val using the first `=`
-        let (k, v) = kv_bytes.iter()
-            .position(|&x| x == b'=')
-            .map_or_else(|| (kv_bytes.to_vec(), None), |idx| (kv_bytes[..idx].to_vec(), Some(kv_bytes[idx + 1..].to_vec())));
+        let (k, v) = kv_bytes.iter().position(|&x| x == b'=').map_or_else(
+            || (kv_bytes.to_vec(), None),
+            |idx| (kv_bytes[..idx].to_vec(), Some(kv_bytes[idx + 1..].to_vec())),
+        );
 
         // Make sure the key can be stored in UTF-8.
         match String::from_utf8(k) {


### PR DESCRIPTION
This PR upgrades clippy to warn about nursery lints ~~on CI~~ and applies said lints.

Applied changes:
* Make applicable functions constants
* Replace usage of `pub(crate)` with `pub` in already private modules.
* Replace unnecessary struct name repetitions (e.g.: when implementing `From` for an enum, inside said functions you dont have to use `Enum::Variant` as it's already implying its usage, therefore using `Self` instead of `Enum`).
* Derive `Eq` for `DnsEntry`, it already implements `PartialEq` but `Eq` is also applicable.
* Replace some ifs/matches with dedicated methods (an example of this is [Option::map_or_else](https://rust-lang.github.io/rust-clippy/master/index.html#/option_if_let_else) which is more cleaner and concise).
* ~~Add `allow(clippy::cognitive_complexity)` for the `service_daemon` module, [the lint](https://rust-lang.github.io/rust-clippy/master/index.html#/cognitive_complexity) rates the complexity of a function and warns if it is exceeded, in this case 2 functions pass the default threshold, the solution to this is to make it smaller by refactoring, splitting it into multiple functions etc (or maybe not possible in some cases), I've added this as solving it would be outside of the PR's scope, so lets make CI pass.~~

This is a 'low-hanging fruit' PR that attempts on making the code a bit more concise (and possible more performant because of the constants and/or dedicated methods for if/match).

Note: the `nursery` lint group are "new lints that are still under development", if you might not want it, I'll remove it from the CI file.