### PR TITLE
feat: extract match addr to type as a function

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -52,6 +52,7 @@ pub const FLAGS_AA: u16 = 0x0400; // mask for Authoritative answer bit
 
 pub type DnsRecordBox = Box<dyn DnsRecordExt + Send>;
 
+#[inline]
 pub const fn ip_address_to_type(address: IpAddr) -> u16 {
     match address {
         IpAddr::V4(_) => TYPE_A,

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -53,7 +53,7 @@ pub const FLAGS_AA: u16 = 0x0400; // mask for Authoritative answer bit
 pub type DnsRecordBox = Box<dyn DnsRecordExt + Send>;
 
 #[inline]
-pub const fn ip_address_to_type(address: IpAddr) -> u16 {
+pub const fn ip_address_to_type(address: &IpAddr) -> u16 {
     match address {
         IpAddr::V4(_) => TYPE_A,
         IpAddr::V6(_) => TYPE_AAAA,
@@ -875,7 +875,7 @@ impl DnsOutgoing {
         for address in intf_addrs {
             self.add_additional_answer(Box::new(DnsAddress::new(
                 service.get_hostname(),
-                ip_address_to_type(address),
+                ip_address_to_type(&address),
                 CLASS_IN | CLASS_CACHE_FLUSH,
                 service.get_host_ttl(),
                 address,

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -52,6 +52,13 @@ pub const FLAGS_AA: u16 = 0x0400; // mask for Authoritative answer bit
 
 pub type DnsRecordBox = Box<dyn DnsRecordExt + Send>;
 
+pub const fn ip_address_to_type(address: IpAddr) -> u16 {
+    match address {
+        IpAddr::V4(_) => TYPE_A,
+        IpAddr::V6(_) => TYPE_AAAA,
+    }
+}
+
 #[derive(Eq, PartialEq, Debug)]
 pub struct DnsEntry {
     pub(crate) name: String, // always lower case.
@@ -865,14 +872,9 @@ impl DnsOutgoing {
         )));
 
         for address in intf_addrs {
-            let t = match address {
-                IpAddr::V4(_) => TYPE_A,
-                IpAddr::V6(_) => TYPE_AAAA,
-            };
-
             self.add_additional_answer(Box::new(DnsAddress::new(
                 service.get_hostname(),
-                t,
+                ip_address_to_type(address),
                 CLASS_IN | CLASS_CACHE_FLUSH,
                 service.get_host_ttl(),
                 address,

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -32,10 +32,10 @@
 use crate::log::{debug, error, warn};
 use crate::{
     dns_parser::{
-        current_time_millis, ip_address_to_type, DnsAddress, DnsIncoming, DnsOutgoing, DnsPointer, DnsRecordBox,
-        DnsRecordExt, DnsSrv, DnsTxt, CLASS_CACHE_FLUSH, CLASS_IN, FLAGS_AA, FLAGS_QR_QUERY,
-        FLAGS_QR_RESPONSE, MAX_MSG_ABSOLUTE, TYPE_A, TYPE_AAAA, TYPE_ANY, TYPE_NSEC, TYPE_PTR,
-        TYPE_SRV, TYPE_TXT,
+        current_time_millis, ip_address_to_type, DnsAddress, DnsIncoming, DnsOutgoing, DnsPointer,
+        DnsRecordBox, DnsRecordExt, DnsSrv, DnsTxt, CLASS_CACHE_FLUSH, CLASS_IN, FLAGS_AA,
+        FLAGS_QR_QUERY, FLAGS_QR_RESPONSE, MAX_MSG_ABSOLUTE, TYPE_A, TYPE_AAAA, TYPE_ANY,
+        TYPE_NSEC, TYPE_PTR, TYPE_SRV, TYPE_TXT,
     },
     error::{Error, Result},
     service_info::{ifaddr_subnet, split_sub_domain, ServiceInfo},

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -565,7 +565,7 @@ impl ServiceDaemon {
                 for (hostname, ip_addr) in
                     zc.cache.refresh_due_hostname_resolutions(hostname).iter()
                 {
-                    zc.send_query(hostname, ip_address_to_type(*ip_addr));
+                    zc.send_query(hostname, ip_address_to_type(ip_addr));
                     query_count += 1;
                 }
             }
@@ -1444,7 +1444,7 @@ impl Zeroconf {
             out.add_answer_at_time(
                 Box::new(DnsAddress::new(
                     info.get_hostname(),
-                    ip_address_to_type(address),
+                    ip_address_to_type(&address),
                     CLASS_IN | CLASS_CACHE_FLUSH,
                     info.get_host_ttl(),
                     address,
@@ -1511,7 +1511,7 @@ impl Zeroconf {
             out.add_answer_at_time(
                 Box::new(DnsAddress::new(
                     info.get_hostname(),
-                    ip_address_to_type(address),
+                    ip_address_to_type(&address),
                     CLASS_IN | CLASS_CACHE_FLUSH,
                     0,
                     address,
@@ -2020,7 +2020,7 @@ impl Zeroconf {
                                     &msg,
                                     Box::new(DnsAddress::new(
                                         &question.entry.name,
-                                        ip_address_to_type(address),
+                                        ip_address_to_type(&address),
                                         CLASS_IN | CLASS_CACHE_FLUSH,
                                         service.get_host_ttl(),
                                         address,
@@ -2077,7 +2077,7 @@ impl Zeroconf {
                     for address in intf_addrs {
                         out.add_additional_answer(Box::new(DnsAddress::new(
                             service.get_hostname(),
-                            ip_address_to_type(address),
+                            ip_address_to_type(&address),
                             CLASS_IN | CLASS_CACHE_FLUSH,
                             service.get_host_ttl(),
                             address,

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -32,7 +32,7 @@
 use crate::log::{debug, error, warn};
 use crate::{
     dns_parser::{
-        current_time_millis, DnsAddress, DnsIncoming, DnsOutgoing, DnsPointer, DnsRecordBox,
+        current_time_millis, ip_address_to_type, DnsAddress, DnsIncoming, DnsOutgoing, DnsPointer, DnsRecordBox,
         DnsRecordExt, DnsSrv, DnsTxt, CLASS_CACHE_FLUSH, CLASS_IN, FLAGS_AA, FLAGS_QR_QUERY,
         FLAGS_QR_RESPONSE, MAX_MSG_ABSOLUTE, TYPE_A, TYPE_AAAA, TYPE_ANY, TYPE_NSEC, TYPE_PTR,
         TYPE_SRV, TYPE_TXT,
@@ -55,7 +55,6 @@ use std::{
     time::Duration,
     vec,
 };
-use crate::dns_parser::ip_address_to_type;
 
 /// A simple macro to report all kinds of errors.
 macro_rules! e_fmt {


### PR DESCRIPTION
I have seen the repeated usage of
```rust
match address {
    IpAddr::V4(_) => TYPE_A,
    IpAddr::V6(_) => TYPE_AAAA,
}
```
in multiple places, although this is a very simple operation, it could be extracted into a function (which is what this PR does).
I'm not really sure if the function name `ip_address_to_type` and its location are appropriate.