### PR TITLE
feat: replace remaining box dns with declared type

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -712,7 +712,7 @@ pub struct DnsOutgoing {
     pub(crate) id: u16,
     multicast: bool,
     pub(crate) questions: Vec<DnsQuestion>,
-    pub(crate) answers: Vec<(Box<dyn DnsRecordExt>, u64)>,
+    pub(crate) answers: Vec<(DnsRecordBox, u64)>,
     pub(crate) authorities: Vec<DnsPointer>,
     pub(crate) additionals: Vec<DnsRecordBox>,
 }
@@ -778,7 +778,7 @@ impl DnsOutgoing {
 
     /// Returns true if `answer` is added to the outgoing msg.
     /// Returns false if `answer` was not added as it expired or suppressed by the incoming `msg`.
-    pub(crate) fn add_answer(&mut self, msg: &DnsIncoming, answer: Box<dyn DnsRecordExt>) -> bool {
+    pub(crate) fn add_answer(&mut self, msg: &DnsIncoming, answer: DnsRecordBox) -> bool {
         debug!("Check for add_answer");
         if !answer.suppressed_by(msg) {
             return self.add_answer_at_time(answer, 0);
@@ -789,7 +789,7 @@ impl DnsOutgoing {
     /// Returns true if `answer` is added to the outgoing msg.
     /// Returns false if the answer is expired `now` hence not added.
     /// If `now` is 0, do not check if the answer expires.
-    pub(crate) fn add_answer_at_time(&mut self, answer: Box<dyn DnsRecordExt>, now: u64) -> bool {
+    pub(crate) fn add_answer_at_time(&mut self, answer: DnsRecordBox, now: u64) -> bool {
         debug!("Check for add_answer_at_time");
         if now == 0 || !answer.get_record().is_expired(now) {
             debug!("add_answer push: {:?}", &answer);


### PR DESCRIPTION
After skimming through the code a bit, I found two usages of `Box<dyn DnsRecordExt>` instead of using the `DnsRecordBox` type (`Box<dyn DnsRecordExt + Send>`).
Although in the replaced remaining cases, we dont really use the `Send` bound but this can be done for consistency sake as there are already other usages of it in places where it isn't necessarily needed.
