### PR TITLE
perf: in adding answers, use static dispatch instead of dynamic dispatch

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -786,7 +786,7 @@ impl DnsOutgoing {
 
     /// Returns true if `answer` is added to the outgoing msg.
     /// Returns false if `answer` was not added as it expired or suppressed by the incoming `msg`.
-    pub(crate) fn add_answer(&mut self, msg: &DnsIncoming, answer: DnsRecordBox) -> bool {
+    pub(crate) fn add_answer(&mut self, msg: &DnsIncoming, answer: Box<dyn DnsRecordExt>) -> bool {
         debug!("Check for add_answer");
         if !answer.suppressed_by(msg) {
             return self.add_answer_at_time(answer, 0);
@@ -797,7 +797,7 @@ impl DnsOutgoing {
     /// Returns true if `answer` is added to the outgoing msg.
     /// Returns false if the answer is expired `now` hence not added.
     /// If `now` is 0, do not check if the answer expires.
-    pub(crate) fn add_answer_at_time(&mut self, answer: DnsRecordBox, now: u64) -> bool {
+    pub(crate) fn add_answer_at_time(&mut self, answer: Box<dyn DnsRecordExt>, now: u64) -> bool {
         debug!("Check for add_answer_at_time");
         if now == 0 || !answer.get_record().is_expired(now) {
             debug!("add_answer push: {:?}", &answer);

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -786,7 +786,11 @@ impl DnsOutgoing {
 
     /// Returns true if `answer` is added to the outgoing msg.
     /// Returns false if `answer` was not added as it expired or suppressed by the incoming `msg`.
-    pub(crate) fn add_answer(&mut self, msg: &DnsIncoming, answer: impl DnsRecordExt + 'static) -> bool {
+    pub(crate) fn add_answer(
+        &mut self,
+        msg: &DnsIncoming,
+        answer: impl DnsRecordExt + 'static,
+    ) -> bool {
         debug!("Check for add_answer");
         if !answer.suppressed_by(msg) {
             return self.add_answer_at_time(answer, 0);
@@ -797,7 +801,11 @@ impl DnsOutgoing {
     /// Returns true if `answer` is added to the outgoing msg.
     /// Returns false if the answer is expired `now` hence not added.
     /// If `now` is 0, do not check if the answer expires.
-    pub(crate) fn add_answer_at_time(&mut self, answer: impl DnsRecordExt + 'static, now: u64) -> bool {
+    pub(crate) fn add_answer_at_time(
+        &mut self,
+        answer: impl DnsRecordExt + 'static,
+        now: u64,
+    ) -> bool {
         debug!("Check for add_answer_at_time");
         if now == 0 || !answer.get_record().is_expired(now) {
             debug!("add_answer push: {:?}", &answer);

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -851,18 +851,18 @@ impl DnsOutgoing {
 
         if let Some(sub) = service.get_subtype() {
             debug!("Adding subdomain {}", sub);
-            self.add_additional_answer(Box::new(DnsPointer::new(
+            self.add_additional_answer(DnsPointer::new(
                 sub,
                 TYPE_PTR,
                 CLASS_IN,
                 service.get_other_ttl(),
                 service.get_fullname().to_string(),
-            )));
+            ));
         }
 
         // Add recommended additional answers according to
         // https://tools.ietf.org/html/rfc6763#section-12.1.
-        self.add_additional_answer(Box::new(DnsSrv::new(
+        self.add_additional_answer(DnsSrv::new(
             service.get_fullname(),
             CLASS_IN | CLASS_CACHE_FLUSH,
             service.get_host_ttl(),
@@ -870,24 +870,24 @@ impl DnsOutgoing {
             service.get_weight(),
             service.get_port(),
             service.get_hostname().to_string(),
-        )));
+        ));
 
-        self.add_additional_answer(Box::new(DnsTxt::new(
+        self.add_additional_answer(DnsTxt::new(
             service.get_fullname(),
             TYPE_TXT,
             CLASS_IN | CLASS_CACHE_FLUSH,
             service.get_host_ttl(),
             service.generate_txt(),
-        )));
+        ));
 
         for address in intf_addrs {
-            self.add_additional_answer(Box::new(DnsAddress::new(
+            self.add_additional_answer(DnsAddress::new(
                 service.get_hostname(),
                 ip_address_to_type(&address),
                 CLASS_IN | CLASS_CACHE_FLUSH,
                 service.get_host_ttl(),
                 address,
-            )));
+            ));
         }
     }
 

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -786,7 +786,7 @@ impl DnsOutgoing {
 
     /// Returns true if `answer` is added to the outgoing msg.
     /// Returns false if `answer` was not added as it expired or suppressed by the incoming `msg`.
-    pub(crate) fn add_answer(&mut self, msg: &DnsIncoming, answer: Box<dyn DnsRecordExt>) -> bool {
+    pub(crate) fn add_answer(&mut self, msg: &DnsIncoming, answer: impl DnsRecordExt + Send + 'static) -> bool {
         debug!("Check for add_answer");
         if !answer.suppressed_by(msg) {
             return self.add_answer_at_time(answer, 0);
@@ -797,11 +797,11 @@ impl DnsOutgoing {
     /// Returns true if `answer` is added to the outgoing msg.
     /// Returns false if the answer is expired `now` hence not added.
     /// If `now` is 0, do not check if the answer expires.
-    pub(crate) fn add_answer_at_time(&mut self, answer: Box<dyn DnsRecordExt>, now: u64) -> bool {
+    pub(crate) fn add_answer_at_time(&mut self, answer: impl DnsRecordExt + Send + 'static, now: u64) -> bool {
         debug!("Check for add_answer_at_time");
         if now == 0 || !answer.get_record().is_expired(now) {
             debug!("add_answer push: {:?}", &answer);
-            self.answers.push((answer, now));
+            self.answers.push((Box::new(answer), now));
             return true;
         }
         false
@@ -827,13 +827,13 @@ impl DnsOutgoing {
 
         let ptr_added = self.add_answer(
             msg,
-            Box::new(DnsPointer::new(
+            DnsPointer::new(
                 service.get_type(),
                 TYPE_PTR,
                 CLASS_IN,
                 service.get_other_ttl(),
                 service.get_fullname().to_string(),
-            )),
+            ),
         );
 
         if !ptr_added {

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -166,7 +166,7 @@ impl PartialEq for DnsRecord {
     }
 }
 
-pub trait DnsRecordExt: fmt::Debug + Send {
+pub trait DnsRecordExt: fmt::Debug {
     fn get_record(&self) -> &DnsRecord;
     fn get_record_mut(&mut self) -> &mut DnsRecord;
     fn write(&self, packet: &mut DnsOutPacket);
@@ -803,7 +803,7 @@ impl DnsOutgoing {
     /// If `now` is 0, do not check if the answer expires.
     pub(crate) fn add_answer_at_time(
         &mut self,
-        answer: impl DnsRecordExt + 'static,
+        answer: impl DnsRecordExt + Send + 'static,
         now: u64,
     ) -> bool {
         debug!("Check for add_answer_at_time");

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -50,7 +50,7 @@ pub const FLAGS_QR_QUERY: u16 = 0x0000;
 pub const FLAGS_QR_RESPONSE: u16 = 0x8000;
 pub const FLAGS_AA: u16 = 0x0400; // mask for Authoritative answer bit
 
-pub type DnsRecordBox = Box<dyn DnsRecordExt + Send>;
+pub type DnsRecordBox = Box<dyn DnsRecordExt>;
 
 #[inline]
 pub const fn ip_address_to_type(address: &IpAddr) -> u16 {
@@ -166,7 +166,7 @@ impl PartialEq for DnsRecord {
     }
 }
 
-pub trait DnsRecordExt: fmt::Debug {
+pub trait DnsRecordExt: fmt::Debug + Send {
     fn get_record(&self) -> &DnsRecord;
     fn get_record_mut(&mut self) -> &mut DnsRecord;
     fn write(&self, packet: &mut DnsOutPacket);
@@ -786,7 +786,7 @@ impl DnsOutgoing {
 
     /// Returns true if `answer` is added to the outgoing msg.
     /// Returns false if `answer` was not added as it expired or suppressed by the incoming `msg`.
-    pub(crate) fn add_answer(&mut self, msg: &DnsIncoming, answer: impl DnsRecordExt + Send + 'static) -> bool {
+    pub(crate) fn add_answer(&mut self, msg: &DnsIncoming, answer: impl DnsRecordExt + 'static) -> bool {
         debug!("Check for add_answer");
         if !answer.suppressed_by(msg) {
             return self.add_answer_at_time(answer, 0);
@@ -797,7 +797,7 @@ impl DnsOutgoing {
     /// Returns true if `answer` is added to the outgoing msg.
     /// Returns false if the answer is expired `now` hence not added.
     /// If `now` is 0, do not check if the answer expires.
-    pub(crate) fn add_answer_at_time(&mut self, answer: impl DnsRecordExt + Send + 'static, now: u64) -> bool {
+    pub(crate) fn add_answer_at_time(&mut self, answer: impl DnsRecordExt + 'static, now: u64) -> bool {
         debug!("Check for add_answer_at_time");
         if now == 0 || !answer.get_record().is_expired(now) {
             debug!("add_answer push: {:?}", &answer);

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1509,7 +1509,7 @@ impl Zeroconf {
                     CLASS_IN | CLASS_CACHE_FLUSH,
                     0,
                     address,
-                )),
+                ),
                 0,
             );
         }
@@ -2775,7 +2775,7 @@ mod tests {
         );
 
         let mut packet_buffer = DnsOutgoing::new(FLAGS_QR_RESPONSE | FLAGS_AA);
-        packet_buffer.add_additional_answer(Box::new(invalidate_ptr_packet));
+        packet_buffer.add_additional_answer(invalidate_ptr_packet);
 
         for intf in intfs {
             let intf_sock = IntfSock {

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1442,13 +1442,13 @@ impl Zeroconf {
         }
         for address in intf_addrs {
             out.add_answer_at_time(
-                Box::new(DnsAddress::new(
+                DnsAddress::new(
                     info.get_hostname(),
                     ip_address_to_type(&address),
                     CLASS_IN | CLASS_CACHE_FLUSH,
                     info.get_host_ttl(),
                     address,
-                )),
+                ),
                 0,
             );
         }
@@ -1460,32 +1460,32 @@ impl Zeroconf {
     fn unregister_service(&self, info: &ServiceInfo, intf_sock: &IntfSock) -> Vec<u8> {
         let mut out = DnsOutgoing::new(FLAGS_QR_RESPONSE | FLAGS_AA);
         out.add_answer_at_time(
-            Box::new(DnsPointer::new(
+            DnsPointer::new(
                 info.get_type(),
                 TYPE_PTR,
                 CLASS_IN,
                 0,
                 info.get_fullname().to_string(),
-            )),
+            ),
             0,
         );
 
         if let Some(sub) = info.get_subtype() {
             debug!("Adding subdomain {}", sub);
             out.add_answer_at_time(
-                Box::new(DnsPointer::new(
+                DnsPointer::new(
                     sub,
                     TYPE_PTR,
                     CLASS_IN,
                     0,
                     info.get_fullname().to_string(),
-                )),
+                ),
                 0,
             );
         }
 
         out.add_answer_at_time(
-            Box::new(DnsSrv::new(
+            DnsSrv::new(
                 info.get_fullname(),
                 CLASS_IN | CLASS_CACHE_FLUSH,
                 0,
@@ -1493,23 +1493,23 @@ impl Zeroconf {
                 info.get_weight(),
                 info.get_port(),
                 info.get_hostname().to_string(),
-            )),
+            ),
             0,
         );
         out.add_answer_at_time(
-            Box::new(DnsTxt::new(
+            DnsTxt::new(
                 info.get_fullname(),
                 TYPE_TXT,
                 CLASS_IN | CLASS_CACHE_FLUSH,
                 0,
                 info.generate_txt(),
-            )),
+            ),
             0,
         );
 
         for address in info.get_addrs_on_intf(&intf_sock.intf) {
             out.add_answer_at_time(
-                Box::new(DnsAddress::new(
+                DnsAddress::new(
                     info.get_hostname(),
                     ip_address_to_type(&address),
                     CLASS_IN | CLASS_CACHE_FLUSH,
@@ -2018,13 +2018,13 @@ impl Zeroconf {
                             for address in intf_addrs {
                                 out.add_answer(
                                     &msg,
-                                    Box::new(DnsAddress::new(
+                                    DnsAddress::new(
                                         &question.entry.name,
                                         ip_address_to_type(&address),
                                         CLASS_IN | CLASS_CACHE_FLUSH,
                                         service.get_host_ttl(),
                                         address,
-                                    )),
+                                    ),
                                 );
                             }
                         }
@@ -2040,7 +2040,7 @@ impl Zeroconf {
                 if qtype == TYPE_SRV || qtype == TYPE_ANY {
                     out.add_answer(
                         &msg,
-                        Box::new(DnsSrv::new(
+                        DnsSrv::new(
                             &question.entry.name,
                             CLASS_IN | CLASS_CACHE_FLUSH,
                             service.get_host_ttl(),
@@ -2048,20 +2048,20 @@ impl Zeroconf {
                             service.get_weight(),
                             service.get_port(),
                             service.get_hostname().to_string(),
-                        )),
+                        ),
                     );
                 }
 
                 if qtype == TYPE_TXT || qtype == TYPE_ANY {
                     out.add_answer(
                         &msg,
-                        Box::new(DnsTxt::new(
+                        DnsTxt::new(
                             &question.entry.name,
                             TYPE_TXT,
                             CLASS_IN | CLASS_CACHE_FLUSH,
                             service.get_host_ttl(),
                             service.generate_txt(),
-                        )),
+                        ),
                     );
                 }
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1388,32 +1388,32 @@ impl Zeroconf {
         debug!("broadcast service {}", service_fullname);
         let mut out = DnsOutgoing::new(FLAGS_QR_RESPONSE | FLAGS_AA);
         out.add_answer_at_time(
-            Box::new(DnsPointer::new(
+            DnsPointer::new(
                 info.get_type(),
                 TYPE_PTR,
                 CLASS_IN,
                 info.get_other_ttl(),
                 info.get_fullname().to_string(),
-            )),
+            ),
             0,
         );
 
         if let Some(sub) = info.get_subtype() {
             debug!("Adding subdomain {}", sub);
             out.add_answer_at_time(
-                Box::new(DnsPointer::new(
+                DnsPointer::new(
                     sub,
                     TYPE_PTR,
                     CLASS_IN,
                     info.get_other_ttl(),
                     info.get_fullname().to_string(),
-                )),
+                ),
                 0,
             );
         }
 
         out.add_answer_at_time(
-            Box::new(DnsSrv::new(
+            DnsSrv::new(
                 info.get_fullname(),
                 CLASS_IN | CLASS_CACHE_FLUSH,
                 info.get_host_ttl(),
@@ -1421,17 +1421,17 @@ impl Zeroconf {
                 info.get_weight(),
                 info.get_port(),
                 info.get_hostname().to_string(),
-            )),
+            ),
             0,
         );
         out.add_answer_at_time(
-            Box::new(DnsTxt::new(
+            DnsTxt::new(
                 info.get_fullname(),
                 TYPE_TXT,
                 CLASS_IN | CLASS_CACHE_FLUSH,
                 info.get_other_ttl(),
                 info.generate_txt(),
-            )),
+            ),
             0,
         );
 
@@ -1977,13 +1977,13 @@ impl Zeroconf {
                     } else if question.entry.name == META_QUERY {
                         let ptr_added = out.add_answer(
                             &msg,
-                            Box::new(DnsPointer::new(
+                            DnsPointer::new(
                                 &question.entry.name,
                                 TYPE_PTR,
                                 CLASS_IN,
                                 service.get_other_ttl(),
                                 service.get_type().to_string(),
-                            )),
+                            ),
                         );
                         if !ptr_added {
                             debug!("answer was not added for meta-query {:?}", &question);
@@ -2069,13 +2069,13 @@ impl Zeroconf {
                         return;
                     }
                     for address in intf_addrs {
-                        out.add_additional_answer(Box::new(DnsAddress::new(
+                        out.add_additional_answer(DnsAddress::new(
                             service.get_hostname(),
                             ip_address_to_type(&address),
                             CLASS_IN | CLASS_CACHE_FLUSH,
                             service.get_host_ttl(),
                             address,
-                        )));
+                        ));
                     }
                 }
             }
@@ -2906,7 +2906,7 @@ mod tests {
             new_service.generate_txt(),
         );
         let mut packet_buffer = DnsOutgoing::new(FLAGS_QR_RESPONSE | FLAGS_AA);
-        packet_buffer.add_answer_at_time(Box::new(txt_with_cache_flush), 0);
+        packet_buffer.add_answer_at_time(txt_with_cache_flush, 0);
 
         for intf in intfs {
             let intf_sock = IntfSock {

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1473,13 +1473,7 @@ impl Zeroconf {
         if let Some(sub) = info.get_subtype() {
             debug!("Adding subdomain {}", sub);
             out.add_answer_at_time(
-                DnsPointer::new(
-                    sub,
-                    TYPE_PTR,
-                    CLASS_IN,
-                    0,
-                    info.get_fullname().to_string(),
-                ),
+                DnsPointer::new(sub, TYPE_PTR, CLASS_IN, 0, info.get_fullname().to_string()),
                 0,
             );
         }


### PR DESCRIPTION
This is an alternative to #206, changes the `answer` type from `Box<dyn DnsRecordExt>` to `impl DnsRecordExt + Send + 'static`.

This replaces the usage of dynamic dispatch on every function call with static dispatch, which in our case should be faster as we always call these functions with new instances (`Box::new(...)`), so the compiler should be able to monomorphize and/or optimize further its usage, as all the possible implementations are now known at compile time.

The dynamic dispatch is still needed for the `answer` field (`Vec<(Box<dyn DnsRecordExt>, u64)>`) in `self.answers.push` of `add_answer_at_time`, but this is done only if needed (when if conditions are met), so this should provide us with only performance improvements, please note that I'm not really a Rust expert or anything, nor have I done benchmarks to provide this (maybe we could add some eventually?).

Edit: forgot to mention that the disadvantages of static dispatch are longer compile times and larger binary size (but I haven't seen significant changes in these)