### PR TITLE
feat: remove clone derive from counter

### DIFF
--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -97,7 +97,7 @@ pub enum DaemonStatus {
 
 /// Different counters included in the metrics.
 /// Currently all counters are for outgoing packets.
-#[derive(Hash, Eq, PartialEq, Clone)]
+#[derive(Hash, Eq, PartialEq)]
 enum Counter {
     Register,
     RegisterResend,


### PR DESCRIPTION
Just a very small nitpick I found (:
For the `Counter` enum, the derive `Clone` isn't used at all, it was added in [this commit](https://github.com/CosminPerRam/mdns-sd/commit/c5a759e9667a904db65b0c8fe9375ed3e02ab26d) for reference.