### PR TITLE
Bugfix: cache flush properly

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -236,6 +236,10 @@ pub trait DnsRecordExt: fmt::Debug {
         self.get_record().get_created()
     }
 
+    fn get_expire(&self) -> u64 {
+        self.get_record().get_expire_time()
+    }
+
     fn set_expire(&mut self, expire_at: u64) {
         self.get_record_mut().set_expire(expire_at);
     }


### PR DESCRIPTION
A follow up fix for issue #203:  we should always check for cache-flush bit, and update expire time for records as needed. 
When addresses changed, we should try to resolve the service again with the updated addresses.

Also refactored integration_success test.