### PR TITLE
Bugfix: logging feature cannot be disabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
           components: rustfmt, clippy
       - name: Run rustfmt and fail if any warnings
         run: cargo fmt -- --check
+      - name: Build with feature configuration
+        run: cargo build --no-default-features --features async
       - name: Build
         run: cargo build
       - name: Run clippy and fail if any warnings

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -517,7 +517,7 @@ impl ServiceDaemon {
                 .filter(|(_, (_, timeout))| timeout.map(|t| now >= t).unwrap_or(false))
                 .map(|(hostname, _)| hostname)
             {
-                log::debug!("hostname resolver timeout for {}", &hostname);
+                debug!("hostname resolver timeout for {}", &hostname);
                 call_hostname_resolution_listener(
                     &zc.hostname_resolvers,
                     &hostname,


### PR DESCRIPTION
Fixing issue #197 .  The extra `log::` in the logging line caused the following feature configuration fails to compile:

`mdns-sd = { version = "0.11", default-features = false, features = ["async"] }`

Also updated CI to catch such build issues in future.