### PR TITLE
refresh PTR records

### DIFF
--- a/examples/query.rs
+++ b/examples/query.rs
@@ -16,7 +16,7 @@
 use mdns_sd::{ServiceDaemon, ServiceEvent};
 
 fn main() {
-    env_logger::init();
+    env_logger::builder().format_timestamp_millis().init();
 
     // Create a daemon
     let mdns = ServiceDaemon::new().expect("Failed to create daemon");

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -2188,7 +2188,7 @@ impl Zeroconf {
         for (ty_domain, _sender) in self.service_queriers.iter() {
             let refreshed_timers = self.cache.refresh_due_ptr(ty_domain);
             if !refreshed_timers.is_empty() {
-                error!("sending refresh query for PTR: {}", ty_domain);
+                debug!("sending refresh query for PTR: {}", ty_domain);
                 self.send_query(ty_domain, TYPE_PTR);
                 query_count += 1;
                 new_timers.extend(refreshed_timers);
@@ -2196,7 +2196,7 @@ impl Zeroconf {
 
             let (instances, timers) = self.cache.refresh_due_srv(ty_domain);
             for instance in instances.iter() {
-                error!("sending refresh query for SRV: {}", instance);
+                debug!("sending refresh query for SRV: {}", instance);
                 self.send_query(instance, TYPE_ANY);
                 query_count += 1;
             }
@@ -2555,7 +2555,7 @@ impl DnsCache {
                 let expired = x.get_record().is_expired(now);
                 if expired {
                     if let Some(dns_ptr) = x.any().downcast_ref::<DnsPointer>() {
-                        error!("expired PTR: {:?}", dns_ptr);
+                        debug!("expired PTR: {:?}", dns_ptr);
                         expired_instances
                             .entry(ty_domain.to_string())
                             .or_insert_with(HashSet::new)

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -308,6 +308,11 @@ impl ServiceInfo {
     pub(crate) fn _set_host_ttl(&mut self, ttl: u32) {
         self.host_ttl = ttl;
     }
+
+    /// other_ttl is for PTR and TXT records.
+    pub(crate) fn _set_other_ttl(&mut self, ttl: u32) {
+        self.other_ttl = ttl;
+    }
 }
 
 /// Removes potentially duplicated ".local." at the end of "hostname".

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -263,6 +263,9 @@ fn service_without_properties_with_alter_net_v4() {
                         info.get_addresses()
                     );
                     // match only our service and not v6 one
+                    if info.get_addresses_v4().is_empty() {
+                        continue;
+                    }
                     if fullname.as_str() == info.get_fullname() {
                         let addrs = info.get_addresses_v4();
                         assert_eq!(addrs.len(), 1); // first_ipv4 but no alter_ipv.


### PR DESCRIPTION
This is to fix issue #216 :

1. In DNS records refresh, currently we always send query for DNS name of service instances. This won't refresh PTR records as their names are the service type (`ty_domain`), not the instance name.

2. Also added missing timers for refresh.
