### PR TITLE
try to fix integration_success test

### DIFF
--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -953,7 +953,11 @@ fn my_ip_interfaces() -> Vec<Interface> {
                     // Use a 'bind' to check if this is a valid IPv6 addr.
                     {
                         let mut sock = std::net::SocketAddrV6::new(ifv6.ip, test_port, 0, 0);
-                        sock.set_scope_id(i.index.unwrap_or(0));
+                        if i.is_link_local() {
+                            // Only link local IPv6 address requires to specify scope_id
+                            sock.set_scope_id(i.index.unwrap_or(0));
+                        }
+
                         match std::net::UdpSocket::bind(sock) {
                             Ok(_) => Some(i),
                             Err(e) => {


### PR DESCRIPTION
This is for debugging / fixing issue #222 .   The test failed due to the following two IPv6 addresses failed to bind in the test but still succeeded in `service_daemon` itself. 

```
bind 2a02:2f08:441b:e100:7015:73e6:324a:f9d3: The requested address is not valid in its context. (os error 10049), skipped.
bind 2a02:2f08:441b:e100:9988:67c9:9723:c99a: The requested address is not valid in its context. (os error 10049), skipped.
```

These two addresses are global unique address (routable) and based on what I've read, they don't need to specify scope id. Trying out this patch.