### PR TITLE
add support for Known Answer Suppression part 1

### DIFF
--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -376,6 +376,10 @@ impl DnsCache {
             .collect()
     }
 
+    /// Returns a list of Known Answer for a given question of `name` with `qtype`.
+    /// The timestamp `now` is passed in to check TTL.
+    ///
+    /// Reference:  RFC 6762 section 7.1
     pub(crate) fn get_known_answers<'a>(
         &'a self,
         name: &str,
@@ -394,6 +398,12 @@ impl DnsCache {
             return Vec::new();
         };
 
+        // From RFC 6762 section 7.1:
+        // ..Generally, this applies only to Shared records, not Unique records,..
+        //
+        // ..a Multicast DNS querier SHOULD NOT include
+        // records in the Known-Answer list whose remaining TTL is less than
+        // half of their original TTL.
         records
             .iter()
             .filter(move |r| !r.get_record().is_unique() && !r.get_record().halflife_passed(now))

--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -394,8 +394,9 @@ impl DnsCache {
             _ => None,
         };
 
-        let Some(records) = records_opt else {
-            return Vec::new();
+        let records = match records_opt {
+            Some(items) => items,
+            None => return Vec::new(),
         };
 
         // From RFC 6762 section 7.1:

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -930,15 +930,16 @@ impl DnsOutgoing {
             return;
         }
 
-        let dns_ptr = DnsPointer::new(
-            service.get_type(),
-            TYPE_PTR,
-            CLASS_IN,
-            service.get_other_ttl(),
-            service.get_fullname().to_string(),
+        let ptr_added = self.add_answer(
+            msg,
+            DnsPointer::new(
+                service.get_type(),
+                TYPE_PTR,
+                CLASS_IN,
+                service.get_other_ttl(),
+                service.get_fullname().to_string(),
+            ),
         );
-
-        let ptr_added = self.add_answer(msg, dns_ptr);
 
         if !ptr_added {
             debug!("answer was not added for msg {:?}", msg);

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -60,7 +60,7 @@ pub const fn ip_address_to_type(address: &IpAddr) -> u16 {
     }
 }
 
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub struct DnsEntry {
     pub(crate) name: String, // always lower case.
     pub(crate) ty: u16,
@@ -88,7 +88,7 @@ pub struct DnsQuestion {
 /// A DNS Resource Record - like a DNS entry, but has a TTL.
 /// RFC: https://www.rfc-editor.org/rfc/rfc1035#section-3.2.1
 ///      https://www.rfc-editor.org/rfc/rfc1035#section-4.1.3
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DnsRecord {
     pub(crate) entry: DnsEntry,
     ttl: u32,     // in seconds, 0 means this record should not be cached
@@ -134,6 +134,16 @@ impl DnsRecord {
 
     pub(crate) const fn refresh_due(&self, now: u64) -> bool {
         now >= self.refresh
+    }
+
+    /// Returns whether `now` (in millis) has passed half of TTL.
+    pub(crate) fn halflife_passed(&self, now: u64) -> bool {
+        let halflife = get_expiration_time(self.created, self.ttl, 50);
+        now > halflife
+    }
+
+    pub(crate) fn is_unique(&self) -> bool {
+        self.entry.cache_flush
     }
 
     /// Updates the refresh time to be the same as the expire time so that
@@ -193,6 +203,14 @@ impl DnsRecord {
         self.created = other.created;
         self.refresh = get_expiration_time(self.created, self.ttl, 80);
         self.expires = get_expiration_time(self.created, self.ttl, 100);
+    }
+
+    /// Modify TTL to reflect the remaining life time from `now`.
+    pub(crate) fn update_ttl(&mut self, now: u64) {
+        if now > self.created {
+            let elapsed = now - self.created;
+            self.ttl -= (elapsed / 1000) as u32;
+        }
     }
 }
 
@@ -259,9 +277,17 @@ pub trait DnsRecordExt: fmt::Debug {
         }
         false
     }
+
+    fn clone_box(&self) -> Box<dyn DnsRecordExt>;
 }
 
-#[derive(Debug)]
+impl Clone for Box<dyn DnsRecordExt> {
+    fn clone(&self) -> Box<dyn DnsRecordExt> {
+        self.clone_box()
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct DnsAddress {
     pub(crate) record: DnsRecord,
     pub(crate) address: IpAddr,
@@ -300,10 +326,14 @@ impl DnsRecordExt for DnsAddress {
         }
         false
     }
+
+    fn clone_box(&self) -> Box<dyn DnsRecordExt> {
+        Box::new(self.clone())
+    }
 }
 
 /// A DNS pointer record
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DnsPointer {
     record: DnsRecord,
     pub(crate) alias: String, // the full name of Service Instance
@@ -339,10 +369,14 @@ impl DnsRecordExt for DnsPointer {
         }
         false
     }
+
+    fn clone_box(&self) -> Box<dyn DnsRecordExt> {
+        Box::new(self.clone())
+    }
 }
 
 // In common cases, there is one and only one SRV record for a particular fullname.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DnsSrv {
     pub(crate) record: DnsRecord,
     pub(crate) priority: u16,
@@ -404,6 +438,10 @@ impl DnsRecordExt for DnsSrv {
         }
         false
     }
+
+    fn clone_box(&self) -> Box<dyn DnsRecordExt> {
+        Box::new(self.clone())
+    }
 }
 
 // From RFC 6763 section 6:
@@ -418,7 +456,7 @@ impl DnsRecordExt for DnsSrv {
 //    marks).  Everything up to the first '=' character is the key (Section
 //    6.4).  Everything after the first '=' character to the end of the
 //    string (including subsequent '=' characters, if any) is the value
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DnsTxt {
     pub(crate) record: DnsRecord,
     pub(crate) text: Vec<u8>,
@@ -455,10 +493,14 @@ impl DnsRecordExt for DnsTxt {
         }
         false
     }
+
+    fn clone_box(&self) -> Box<dyn DnsRecordExt> {
+        Box::new(self.clone())
+    }
 }
 
 /// A DNS host information record
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct DnsHostInfo {
     record: DnsRecord,
     cpu: String,
@@ -499,6 +541,10 @@ impl DnsRecordExt for DnsHostInfo {
         }
         false
     }
+
+    fn clone_box(&self) -> Box<dyn DnsRecordExt> {
+        Box::new(self.clone())
+    }
 }
 
 /// Record for negative responses
@@ -506,7 +552,7 @@ impl DnsRecordExt for DnsHostInfo {
 /// [RFC4034 section 4.1](https://datatracker.ietf.org/doc/html/rfc4034#section-4.1)
 /// and
 /// [RFC6762 section 6.1](https://datatracker.ietf.org/doc/html/rfc6762#section-6.1)
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DnsNSec {
     record: DnsRecord,
     next_domain: String,
@@ -577,6 +623,10 @@ impl DnsRecordExt for DnsNSec {
                 && self.record.entry == other_record.record.entry;
         }
         false
+    }
+
+    fn clone_box(&self) -> Box<dyn DnsRecordExt> {
+        Box::new(self.clone())
     }
 }
 
@@ -826,6 +876,11 @@ impl DnsOutgoing {
         self.additionals.push(Box::new(answer));
     }
 
+    /// A workaround as Rust doesn't allow us to pass DnsRecordBox in as `impl DnsRecordExt`
+    pub(crate) fn add_additional_answer_box(&mut self, answer_box: DnsRecordBox) {
+        self.additionals.push(answer_box);
+    }
+
     /// Returns true if `answer` is added to the outgoing msg.
     /// Returns false if `answer` was not added as it expired or suppressed by the incoming `msg`.
     pub(crate) fn add_answer(
@@ -875,16 +930,15 @@ impl DnsOutgoing {
             return;
         }
 
-        let ptr_added = self.add_answer(
-            msg,
-            DnsPointer::new(
-                service.get_type(),
-                TYPE_PTR,
-                CLASS_IN,
-                service.get_other_ttl(),
-                service.get_fullname().to_string(),
-            ),
+        let dns_ptr = DnsPointer::new(
+            service.get_type(),
+            TYPE_PTR,
+            CLASS_IN,
+            service.get_other_ttl(),
+            service.get_fullname().to_string(),
         );
+
+        let ptr_added = self.add_answer(msg, dns_ptr);
 
         if !ptr_added {
             debug!("answer was not added for msg {:?}", msg);

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -110,6 +110,7 @@ enum Counter {
     CacheRefreshPTR,
     CacheRefreshSRV,
     CacheRefreshAddr,
+    KnownAnswerSuppression,
 }
 
 impl fmt::Display for Counter {
@@ -125,6 +126,7 @@ impl fmt::Display for Counter {
             Self::CacheRefreshPTR => write!(f, "cache-refresh-ptr"),
             Self::CacheRefreshSRV => write!(f, "cache-refresh-srv"),
             Self::CacheRefreshAddr => write!(f, "cache-refresh-addr"),
+            Self::KnownAnswerSuppression => write!(f, "known-answer-suppression"),
         }
     }
 }
@@ -1817,7 +1819,7 @@ impl Zeroconf {
         const META_QUERY: &str = "_services._dns-sd._udp.local.";
 
         for question in msg.questions.iter() {
-            debug!("question: {:?}", &question);
+            debug!("query question: {:?}", &question);
             let qtype = question.entry.ty;
 
             if qtype == TYPE_PTR {
@@ -1942,6 +1944,8 @@ impl Zeroconf {
 
             self.increase_counter(Counter::Respond, 1);
         }
+
+        self.increase_counter(Counter::KnownAnswerSuppression, out.known_answer_count);
     }
 
     /// Increases the value of `counter` by `count`.

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1335,3 +1335,76 @@ fn test_cache_flush_remove_one_addr() {
     server.shutdown().unwrap();
     client.shutdown().unwrap();
 }
+
+#[test]
+fn test_known_answer_suppression() {
+    // Create a daemon
+    let mdns_server = ServiceDaemon::new().expect("Failed to create mdns server");
+
+    // Register a service
+    let ty_domain = "_known-answer._udp.local.";
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap();
+    let instance_name = now.as_micros().to_string(); // Create a unique name.
+
+    // Get a single IPv4 address
+    let ip_addr1 = my_ip_interfaces()
+        .iter()
+        .find(|iface| iface.ip().is_ipv4())
+        .map(|iface| iface.ip())
+        .unwrap();
+
+    let host_name = "known_answer_server.local.";
+    let port = 5200;
+
+    let my_service = ServiceInfo::new(ty_domain, &instance_name, host_name, &ip_addr1, port, None)
+        .expect("valid service info");
+    mdns_server
+        .register(my_service)
+        .expect("Failed to register my service");
+
+    // Browse the server
+    let client = ServiceDaemon::new().expect("Failed to create mdns client");
+    let browse_chan = client.browse(ty_domain).unwrap();
+    let timeout = Duration::from_secs(2);
+    let mut resolved = false;
+
+    while let Ok(event) = browse_chan.recv_timeout(timeout) {
+        match event {
+            ServiceEvent::ServiceResolved(info) => {
+                resolved = true;
+                println!("Resolved a service of {}", &info.get_fullname());
+                break;
+            }
+            _ => {}
+        }
+    }
+    assert!(resolved);
+
+    // Verify the server respond counter is 1.
+    let metrics_receiver = mdns_server.get_metrics().unwrap();
+    let metrics = metrics_receiver.recv().unwrap();
+    assert_eq!(metrics["respond"], 1);
+
+    // Browse again
+    let browse_chan = client.browse(ty_domain).unwrap();
+    resolved = false;
+
+    while let Ok(event) = browse_chan.recv_timeout(timeout) {
+        match event {
+            ServiceEvent::ServiceResolved(info) => {
+                resolved = true;
+                println!("Resolved a service of {}", &info.get_fullname());
+                break;
+            }
+            _ => {}
+        }
+    }
+    assert!(resolved);
+
+    // Verify that no new response from the server due to known answer suppression.
+    let metrics_receiver = mdns_server.get_metrics().unwrap();
+    let metrics = metrics_receiver.recv().unwrap();
+    assert_eq!(metrics["respond"], 1);
+}

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1358,17 +1358,18 @@ fn test_known_answer_suppression() {
     let host_name = "known_answer_server.local.";
     let port = 5200;
 
+    // Browse the service first, to avoid the possible publish packets already cached by the system.
+    let client = ServiceDaemon::new().expect("Failed to create mdns client");
+    let browse_chan = client.browse(ty_domain).unwrap();
+    let timeout = Duration::from_secs(2);
+    let mut resolved = false;
+
+    // Publish the service
     let my_service = ServiceInfo::new(ty_domain, &instance_name, host_name, &ip_addr1, port, None)
         .expect("valid service info");
     mdns_server
         .register(my_service)
         .expect("Failed to register my service");
-
-    // Browse the server
-    let client = ServiceDaemon::new().expect("Failed to create mdns client");
-    let browse_chan = client.browse(ty_domain).unwrap();
-    let timeout = Duration::from_secs(2);
-    let mut resolved = false;
 
     while let Ok(event) = browse_chan.recv_timeout(timeout) {
         match event {

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1377,7 +1377,9 @@ fn test_known_answer_suppression() {
                 println!("Resolved a service of {}", &info.get_fullname());
                 break;
             }
-            _ => {}
+            other => {
+                println!("Received event {:?}", other);
+            }
         }
     }
     assert!(resolved);

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1385,6 +1385,7 @@ fn test_known_answer_suppression() {
     // Verify the server respond counter is 1.
     let metrics_receiver = mdns_server.get_metrics().unwrap();
     let metrics = metrics_receiver.recv().unwrap();
+    println!("metrics: {:?}", &metrics);
     assert_eq!(metrics["respond"], 1);
 
     // Browse again


### PR DESCRIPTION
This is to resolve issue #193 item 1 (i.e. RFC 6762 section 7.1 Known Answer Suppression) 

- Added `clone_box()` to `DnsRecordExt` to support clone.
- Added a new test case for Known Answer Suppression (but more tests are needed to have full coverage).

Also ran test with debug message to confirm:
`[2024-06-16T04:30:13Z DEBUG mdns_sd::service_daemon] Sending query questions: [("_known-answer._udp.local.", 12)]`
`[2024-06-16T04:30:13Z DEBUG mdns_sd::service_daemon] add known answer: DnsPointer { record: DnsRecord { entry: DnsEntry { name: "_known-answer._udp.local.", ty: 12, class: 1, cache_flush: false }, ttl: 4500, created: 1718512213174, expires: 1718516713174, refresh: 1718515813174 }, alias: "1718512213167281._known-answer._udp.local." }`