### PR TITLE
enable DEBUG logging for a failed test in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,5 +30,9 @@ jobs:
         run: cargo build
       - name: Run clippy and fail if any warnings
         run: cargo clippy -- -D warnings
-      - name: Run tests
+      - name: Run tests with debugs
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
         run: RUST_LOG=debug cargo test
+      - name: Run tests on Windows
+        if: matrix.os == 'windows-latest'
+        run: cargo test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,5 +30,7 @@ jobs:
         run: cargo build
       - name: Run clippy and fail if any warnings
         run: cargo clippy -- -D warnings
+      - name: Run a flaky test
+        run: RUST_LOG=debug cargo test test_cache_flush_record
       - name: Run tests
         run: cargo test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,5 @@ jobs:
         run: cargo build
       - name: Run clippy and fail if any warnings
         run: cargo clippy -- -D warnings
-      - name: Run a flaky test
-        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
-        run: RUST_LOG=debug cargo test test_cache_flush_record
       - name: Run tests
-        run: cargo test
+        run: RUST_LOG=debug cargo test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Run clippy and fail if any warnings
         run: cargo clippy -- -D warnings
       - name: Run a flaky test
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
         run: RUST_LOG=debug cargo test test_cache_flush_record
       - name: Run tests
         run: cargo test

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -947,7 +947,7 @@ impl DnsOutgoing {
         );
 
         if !ptr_added {
-            debug!("answer was not added for msg {:?}", msg);
+            debug!("PTR answer was not added for ServiceInfo {:?}", service);
             return;
         }
 
@@ -1270,7 +1270,7 @@ impl DnsIncoming {
             }
 
             if let Some(record) = rec {
-                debug!("{:?}", &record);
+                debug!("DnsIncoming: read_others: {:?}", &record);
                 self.answers.push(record);
             }
         }

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -947,7 +947,7 @@ impl DnsOutgoing {
         );
 
         if !ptr_added {
-            debug!("PTR answer was not added for ServiceInfo {:?}", service);
+            debug!("answer was not added for msg {:?}", msg);
             return;
         }
 
@@ -1270,7 +1270,7 @@ impl DnsIncoming {
             }
 
             if let Some(record) = rec {
-                debug!("DnsIncoming: read_others: {:?}", &record);
+                debug!("read_others: {:?}", &record);
                 self.answers.push(record);
             }
         }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1526,7 +1526,7 @@ impl Zeroconf {
                     if info.is_ready() {
                         resolved.insert(ptr.alias.clone());
                         match sender.send(ServiceEvent::ServiceResolved(info)) {
-                            Ok(()) => debug!("sent service resolved"),
+                            Ok(()) => debug!("sent service resolved: {}", &ptr.alias),
                             Err(e) => error!("failed to send service resolved: {}", e),
                         }
                     } else {

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1531,7 +1531,6 @@ impl Zeroconf {
                         }
                     } else {
                         unresolved.insert(ptr.alias.clone());
-                        debug!("ServiceInfo not ready: {:?}", &info);
                     }
                 }
             }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1531,6 +1531,7 @@ impl Zeroconf {
                         }
                     } else {
                         unresolved.insert(ptr.alias.clone());
+                        debug!("ServiceInfo not ready: {:?}", &info);
                     }
                 }
             }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1133,7 +1133,9 @@ fn hostname_resolution_timeout() {
 #[test]
 fn test_cache_flush_record() {
     // For debugging a failure in CI only.
-    env_logger::Builder::new().filter_level(log::LevelFilter::Debug).init();
+    env_logger::Builder::new()
+        .filter_level(log::LevelFilter::Debug)
+        .init();
 
     // Create a daemon
     let server = ServiceDaemon::new().expect("Failed to create server");

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::thread::sleep;
 use std::time::{Duration, SystemTime};
-use test_log::test;
+// use test_log::test; // commented out to debug a failure in GitHub CI only.
 
 /// This test covers:
 /// register(announce), browse(query), response, unregister, shutdown.
@@ -1132,6 +1132,9 @@ fn hostname_resolution_timeout() {
 
 #[test]
 fn test_cache_flush_record() {
+    // For debugging a failure in CI only.
+    env_logger::Builder::new().filter_level(log::LevelFilter::Debug).init();
+
     // Create a daemon
     let server = ServiceDaemon::new().expect("Failed to create server");
     let service = "_test_cache_ptr._udp.local.";

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1135,6 +1135,7 @@ fn test_cache_flush_record() {
     // For debugging a failure in CI only.
     env_logger::Builder::new()
         .filter_level(log::LevelFilter::Debug)
+        .target(env_logger::Target::Stdout)
         .init();
 
     // Create a daemon

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::thread::sleep;
 use std::time::{Duration, SystemTime};
-use test_log::test;
+// use test_log::test; // commented out for debugging a flaky test in CI.
 
 /// This test covers:
 /// register(announce), browse(query), response, unregister, shutdown.
@@ -1130,7 +1130,7 @@ fn hostname_resolution_timeout() {
     d.shutdown().unwrap();
 }
 
-#[test]
+#[test_log::test]
 fn test_cache_flush_record() {
     // Create a daemon
     let server = ServiceDaemon::new().expect("Failed to create server");

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::thread::sleep;
 use std::time::{Duration, SystemTime};
-// use test_log::test; // commented out to debug a failure in GitHub CI only.
+use test_log::test;
 
 /// This test covers:
 /// register(announce), browse(query), response, unregister, shutdown.
@@ -1132,25 +1132,6 @@ fn hostname_resolution_timeout() {
 
 #[test]
 fn test_cache_flush_record() {
-    // For debugging a failure in CI only.
-    use std::io::Write;
-    let thread_id = std::thread::current().id();
-    env_logger::builder()
-        .filter_level(log::LevelFilter::Debug)
-        .target(env_logger::Target::Stdout)
-        .format(move |buf, record| {
-            let ts = buf.timestamp_millis();
-            writeln!(
-                buf,
-                "{}: {:?}: {}: {}",
-                ts,
-                thread_id,
-                record.level(),
-                record.args()
-            )
-        })
-        .init();
-
     // Create a daemon
     let server = ServiceDaemon::new().expect("Failed to create server");
     let service = "_test_cache_ptr._udp.local.";

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1133,9 +1133,22 @@ fn hostname_resolution_timeout() {
 #[test]
 fn test_cache_flush_record() {
     // For debugging a failure in CI only.
-    env_logger::Builder::new()
+    use std::io::Write;
+    let thread_id = std::thread::current().id();
+    env_logger::builder()
         .filter_level(log::LevelFilter::Debug)
         .target(env_logger::Target::Stdout)
+        .format(move |buf, record| {
+            let ts = buf.timestamp_millis();
+            writeln!(
+                buf,
+                "{}: {:?}: {}: {}",
+                ts,
+                thread_id,
+                record.level(),
+                record.args()
+            )
+        })
         .init();
 
     // Create a daemon


### PR DESCRIPTION
This is to help debugging the cause of a recent test failure only seen in [GitHub CI](https://github.com/keepsimple1/mdns-sd/actions/runs/9539722070/job/26290395605). 