### PR TITLE
Avoid redundant query, announcement and unregistration overhaul

### DIFF
--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1393,7 +1393,7 @@ impl Zeroconf {
 
     /// Sends a multicast query for `name` with `qtype`.
     fn send_query(&self, name: &str, qtype: u16) {
-        self.send_query_vec(&[(name, qtype)])
+        self.send_query_vec(&[(name, qtype)]);
     }
 
     /// Sends out a list of `questions` (i.e. DNS questions) via multicast.

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1241,16 +1241,13 @@ impl Zeroconf {
 
         for (_, intf_sock) in self.intf_socks.iter() {
             if let Some(tracker) = intf_sock.multicast_send_tracker() {
-                if multicast_sent_trackers
-                    .contains(&tracker)
-                {
+                if multicast_sent_trackers.contains(&tracker) {
                     continue; // No need to send again on the same interface with same ip version.
                 }
             }
             if self.broadcast_service_on_intf(info, intf_sock) {
                 if let Some(tracker) = intf_sock.multicast_send_tracker() {
-                    multicast_sent_trackers
-                        .insert(tracker);
+                    multicast_sent_trackers.insert(tracker);
                 }
                 outgoing_addrs.push(intf_sock.intf.ip());
             }
@@ -1446,13 +1443,10 @@ impl Zeroconf {
         let mut multicast_sent_trackers = HashSet::new();
         for (_, intf_sock) in self.intf_socks.iter() {
             if let Some(tracker) = intf_sock.multicast_send_tracker() {
-                if multicast_sent_trackers
-                    .contains(&tracker)
-                {
+                if multicast_sent_trackers.contains(&tracker) {
                     continue; // no need to send query the same interface with same ip version.
                 }
-                multicast_sent_trackers
-                    .insert(tracker);
+                multicast_sent_trackers.insert(tracker);
             }
             send_dns_outgoing(&out, intf_sock);
         }
@@ -1879,9 +1873,9 @@ impl Zeroconf {
                 for service in self.my_services.values() {
                     if question.entry.name == service.get_type()
                         || service
-                        .get_subtype()
-                        .as_ref()
-                        .map_or(false, |v| v == &question.entry.name)
+                            .get_subtype()
+                            .as_ref()
+                            .map_or(false, |v| v == &question.entry.name)
                     {
                         out.add_answer_with_additionals(&msg, service, &intf_sock.intf);
                     } else if question.entry.name == META_QUERY {
@@ -2157,13 +2151,10 @@ impl Zeroconf {
 
                 for (ip, intf_sock) in self.intf_socks.iter() {
                     if let Some(tracker) = intf_sock.multicast_send_tracker() {
-                        if multicast_sent_trackers
-                            .contains(&tracker)
-                        {
+                        if multicast_sent_trackers.contains(&tracker) {
                             continue; // no need to send unregister the same interface with same ip version.
                         }
-                        multicast_sent_trackers
-                            .insert(tracker);
+                        multicast_sent_trackers.insert(tracker);
                     }
                     let packet = self.unregister_service(&info, intf_sock);
                     // repeat for one time just in case some peers miss the message
@@ -2858,7 +2849,7 @@ mod tests {
             1234,
             None,
         )
-            .expect("invalid service info");
+        .expect("invalid service info");
 
         // Set a short TTL for addresses for testing.
         let addr_ttl = 2;
@@ -2934,7 +2925,7 @@ mod tests {
             5023,
             None,
         )
-            .unwrap();
+        .unwrap();
 
         let new_ttl = 2; // for testing only.
         my_service._set_other_ttl(new_ttl);

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1,4 +1,4 @@
-///! Service daemon for mDNS Service Discovery.
+//! Service daemon for mDNS Service Discovery.
 
 // How DNS-based Service Discovery works in a nutshell:
 //

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -39,7 +39,7 @@ use crate::{
         TYPE_PTR, TYPE_SRV, TYPE_TXT,
     },
     error::{Error, Result},
-    service_info::{ServiceInfo},
+    service_info::ServiceInfo,
     Receiver,
 };
 use flume::{bounded, Sender, TrySendError};
@@ -2121,8 +2121,8 @@ impl Zeroconf {
 
                 let mut intf_af_set: HashSet<(u32, u8)> = HashSet::new();
                 for (ip, intf_sock) in self.intf_socks.iter() {
-                    let af=  match ip  {
-                        IpAddr::V4(_)  => 4u8,
+                    let af = match ip {
+                        IpAddr::V4(_) => 4u8,
                         IpAddr::V6(_) => 6u8,
                     };
                     let itf_af = (intf_sock.intf.index.unwrap_or(0), af);

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -773,12 +773,12 @@ struct IntfSock {
 impl IntfSock {
     /// Returns the interface index and the associated ip version
     fn intf_idx_ip_ver(&self) -> (u32, u8) {
-        let af = match self.intf.addr {
+        let ip_ver = match self.intf.addr {
             IfAddr::V4(_) => 4u8,
             IfAddr::V6(_) => 6u8,
         };
 
-        (self.intf.index.unwrap_or(0), af)
+        (self.intf.index.unwrap_or(0), ip_ver)
     }
 }
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1441,7 +1441,7 @@ impl Zeroconf {
         }
 
         // Send the query on one interface per ip version.
-        let mut intf_idx_ip_ver_set= HashSet::new();
+        let mut intf_idx_ip_ver_set = HashSet::new();
         for (_, intf_sock) in self.intf_socks.iter() {
             if intf_sock.intf_idx_ip_ver().is_valid() {
                 if intf_idx_ip_ver_set.contains(&intf_sock.intf_idx_ip_ver()) {
@@ -2148,7 +2148,7 @@ impl Zeroconf {
             Some((_k, info)) => {
                 let mut timers = Vec::new();
                 // Send one unregister per interface and ip version
-                let mut intf_idx_ip_ver_set= HashSet::new();
+                let mut intf_idx_ip_ver_set = HashSet::new();
 
                 for (ip, intf_sock) in self.intf_socks.iter() {
                     if intf_sock.intf_idx_ip_ver().is_valid() {

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -724,15 +724,6 @@ pub fn valid_ip_on_intf(addr: &IpAddr, intf: &Interface) -> bool {
     }
 }
 
-/// Returns the bitwise and (&) of the netmask and ip parts of `addr` as `u128` for IPv4 and IPv6 address.
-/// Suitable for checking if two networks are on the same subnet.
-pub fn ifaddr_subnet(addr: &IfAddr) -> u128 {
-    match addr {
-        IfAddr::V4(addrv4) => (u32::from(addrv4.netmask) & u32::from(addrv4.ip)) as u128,
-        IfAddr::V6(addrv6) => u128::from(addrv6.netmask) & u128::from(addrv6.ip),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::{decode_txt, encode_txt, u8_slice_to_hex, ServiceInfo, TxtProperty};

--- a/test.cmd
+++ b/test.cmd
@@ -1,0 +1,8 @@
+@echo off
+:loop
+echo Running cargo test...
+cargo test --release --test mdns_test
+echo.
+echo Press Ctrl+C to stop or wait for the next run...
+timeout /t 1 /nobreak >nul
+goto loop

--- a/test.cmd
+++ b/test.cmd
@@ -1,8 +1,0 @@
-@echo off
-:loop
-echo Running cargo test...
-cargo test --release --test mdns_test
-echo.
-echo Press Ctrl+C to stop or wait for the next run...
-timeout /t 1 /nobreak >nul
-goto loop

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -23,7 +23,23 @@ fn integration_success() {
         .unwrap();
     let instance_name = now.as_micros().to_string(); // Create a unique name.
 
-    let ifaddrs_set: HashSet<_> = my_ip_interfaces().iter().map(|intf| intf.ip()).collect();
+    let mut itf_af_set : HashSet<(u32, u8)> = HashSet::new();
+    let mut all_itfs = my_ip_interfaces();
+    all_itfs.retain(|itf| {
+        let af = match itf.addr {
+            IfAddr::V4(_) => 4u8,
+            IfAddr::V6(_) => 6u8,
+        };
+        let l = (itf.index.unwrap_or(0), af);
+        if itf_af_set.contains(&l) {
+            false
+        } else {
+            itf_af_set.insert(l);
+            true
+        }
+    });
+
+    let ifaddrs_set: HashSet<_> = all_itfs.iter().map(|intf| intf.ip()).collect();
     let my_ifaddrs: Vec<_> = ifaddrs_set.into_iter().collect();
     let my_addrs_count = my_ifaddrs.len();
     println!("My IP {} addr(s):", my_ifaddrs.len());

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -23,7 +23,7 @@ fn integration_success() {
         .unwrap();
     let instance_name = now.as_micros().to_string(); // Create a unique name.
 
-    let mut itf_af_set : HashSet<(u32, u8)> = HashSet::new();
+    let mut itf_af_set: HashSet<(u32, u8)> = HashSet::new();
     let mut all_itfs = my_ip_interfaces();
     all_itfs.retain(|itf| {
         let af = match itf.addr {

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -25,7 +25,7 @@ fn integration_success() {
 
     let all_interfaces = my_ip_interfaces();
     // as we send only once per interface and ip we need a count of unique addresses to verify number of sent unregisters later on
-    let uniq_multicast_addrs = all_interfaces.iter().map(|itf| {
+    let unique_multicast_itf_idx_ip_ver_set = all_interfaces.iter().map(|itf| {
         let ip_ver = match itf.addr {
             IfAddr::V4(_) => 4u8,
             IfAddr::V6(_) => 6u8,
@@ -175,7 +175,7 @@ fn integration_success() {
     assert_eq!(metrics["register"], 1);
     assert_eq!(metrics["unregister"], 1);
     assert_eq!(metrics["register-resend"], 1);
-    assert_eq!(metrics["unregister-resend"], uniq_multicast_addrs.len() as i64);
+    assert_eq!(metrics["unregister-resend"], unique_multicast_itf_idx_ip_ver_set.len() as i64);
     assert!(metrics["browse"] >= 2); // browse has been retransmitted.
 
     // respond has been sent for every browse, or they are suppressed by "known answer".

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -25,13 +25,16 @@ fn integration_success() {
 
     let all_interfaces = my_ip_interfaces();
     // as we send only once per interface and ip we need a count of unique addresses to verify number of sent unregisters later on
-    let unique_multicast_itf_idx_ip_ver_set = all_interfaces.iter().map(|itf| {
-        let ip_ver = match itf.addr {
-            IfAddr::V4(_) => 4u8,
-            IfAddr::V6(_) => 6u8,
-        };
-        (itf.index.unwrap_or(0), ip_ver)
-    }).collect::<HashSet<_>>();
+    let unique_multicast_itf_idx_ip_ver_set = all_interfaces
+        .iter()
+        .map(|itf| {
+            let ip_ver = match itf.addr {
+                IfAddr::V4(_) => 4u8,
+                IfAddr::V6(_) => 6u8,
+            };
+            (itf.index.unwrap_or(0), ip_ver)
+        })
+        .collect::<HashSet<_>>();
 
     let ifaddrs_set: HashSet<_> = all_interfaces.iter().map(|intf| intf.ip()).collect();
     let my_ifaddrs: Vec<_> = ifaddrs_set.into_iter().collect();
@@ -175,7 +178,10 @@ fn integration_success() {
     assert_eq!(metrics["register"], 1);
     assert_eq!(metrics["unregister"], 1);
     assert_eq!(metrics["register-resend"], 1);
-    assert_eq!(metrics["unregister-resend"], unique_multicast_itf_idx_ip_ver_set.len() as i64);
+    assert_eq!(
+        metrics["unregister-resend"],
+        unique_multicast_itf_idx_ip_ver_set.len() as i64
+    );
     assert!(metrics["browse"] >= 2); // browse has been retransmitted.
 
     // respond has been sent for every browse, or they are suppressed by "known answer".

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -23,23 +23,17 @@ fn integration_success() {
         .unwrap();
     let instance_name = now.as_micros().to_string(); // Create a unique name.
 
-    let mut itf_af_set: HashSet<(u32, u8)> = HashSet::new();
-    let mut all_itfs = my_ip_interfaces();
-    all_itfs.retain(|itf| {
-        let af = match itf.addr {
+    let all_interfaces = my_ip_interfaces();
+    // as we send only once per interface and ip we need a count of unique addresses to verify number of sent unregisters later on
+    let uniq_multicast_addrs = all_interfaces.iter().map(|itf| {
+        let ip_ver = match itf.addr {
             IfAddr::V4(_) => 4u8,
             IfAddr::V6(_) => 6u8,
         };
-        let l = (itf.index.unwrap_or(0), af);
-        if itf_af_set.contains(&l) {
-            false
-        } else {
-            itf_af_set.insert(l);
-            true
-        }
-    });
+        (itf.index.unwrap_or(0), ip_ver)
+    }).collect::<HashSet<_>>();
 
-    let ifaddrs_set: HashSet<_> = all_itfs.iter().map(|intf| intf.ip()).collect();
+    let ifaddrs_set: HashSet<_> = all_interfaces.iter().map(|intf| intf.ip()).collect();
     let my_ifaddrs: Vec<_> = ifaddrs_set.into_iter().collect();
     let my_addrs_count = my_ifaddrs.len();
     println!("My IP {} addr(s):", my_ifaddrs.len());
@@ -181,7 +175,7 @@ fn integration_success() {
     assert_eq!(metrics["register"], 1);
     assert_eq!(metrics["unregister"], 1);
     assert_eq!(metrics["register-resend"], 1);
-    assert_eq!(metrics["unregister-resend"], my_ifaddrs.len() as i64);
+    assert_eq!(metrics["unregister-resend"], uniq_multicast_addrs.len() as i64);
     assert!(metrics["browse"] >= 2); // browse has been retransmitted.
 
     // respond has been sent for every browse, or they are suppressed by "known answer".


### PR DESCRIPTION
I had a second thought about the "already sent query or announcemnet in the subnet approach".

Using a "subnet" to filter already notified multicast groups on IPv4 or IPv6 is not a effective method in a multicast context.

The socket used to send multicast traffic is acutally bound to the "any" address associated with the respective address family and is joined on the mDNS multicast_v(4|6) address using the network interface index. 

If we have multiple IPv6 or IPv4 addresses on the same network interface in different **subnets**, this will result in redundant traffic to be sent when sending queries, unregistration messages or announcements, as we still sent those to the same multicast group on the same interface.

I've came up with another approach. We use a tuple(interface index , adress family ) in a set to track already "used" notifications.

This reduces the number of messages sent drastically for example on my windows machine, i'm getting 3 IPv6 addresses and one IPv4 address. Before this change this would result in 4 messages being send on that interface. With this change we only send 2.

@keepsimple1 Please, let me know if there are any problems with the approach.

