### PR TITLE
Refresh A and AAAA records of active `.browse` queriers

### DIFF
--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -210,7 +210,7 @@ impl DnsCache {
     pub(crate) fn evict_expired_addr(&mut self, now: u64) -> HashMap<String, HashSet<IpAddr>> {
         let mut removed = HashMap::new();
 
-        for records in self.addr.values_mut() {
+        self.addr.retain(|_, records| {
             records.retain(|addr| {
                 let expired = addr.get_record().is_expired(now);
                 if expired {
@@ -222,8 +222,10 @@ impl DnsCache {
                     }
                 }
                 !expired
-            })
-        }
+            });
+
+            !records.is_empty()
+        });
 
         removed
     }
@@ -345,6 +347,68 @@ impl DnsCache {
             }
         }
 
+        (refresh_due, new_timers)
+    }
+
+    /// Returns the set of `host`, where refreshing the A / AAAA records is due
+    /// for a `ty_domain`.
+    pub(crate) fn refresh_due_hosts(&mut self, ty_domain: &str) -> (HashSet<String>, HashSet<u64>) {
+        let now = current_time_millis();
+
+        let mut instances = vec![];
+
+        // find instance names for ty_domain.
+        for record in self.ptr.get_mut(ty_domain).into_iter().flatten() {
+            if record.get_record().is_expired(now) {
+                continue;
+            }
+
+            if let Some(ptr) = record.any().downcast_ref::<DnsPointer>() {
+                instances.push(ptr.alias.clone());
+            }
+        }
+
+        // Collect hostnames we have browsers for by SRV records.
+        let mut hostnames_browsed = HashSet::new();
+        for instance in instances {
+            let hosts: HashSet<String> = self
+                .srv
+                .get(&instance)
+                .into_iter()
+                .flatten()
+                .filter_map(|record| {
+                    if let Some(srv) = record.any().downcast_ref::<DnsSrv>() {
+                        Some(srv.host.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            hostnames_browsed.extend(hosts);
+        }
+        let mut refresh_due = HashSet::new();
+        let mut new_timers = HashSet::new();
+        for hostname in hostnames_browsed {
+            let refresh_timers: HashSet<u64> = self
+                .addr
+                .get_mut(&hostname)
+                .into_iter()
+                .flatten()
+                .filter_map(|record| {
+                    if record.get_record_mut().refresh_maybe(now) {
+                        Some(record.get_record().get_refresh_time())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            if !refresh_timers.is_empty() {
+                refresh_due.insert(hostname);
+                new_timers.extend(refresh_timers);
+            }
+        }
         (refresh_due, new_timers)
     }
 

--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -377,11 +377,10 @@ impl DnsCache {
                 .into_iter()
                 .flatten()
                 .filter_map(|record| {
-                    if let Some(srv) = record.any().downcast_ref::<DnsSrv>() {
-                        Some(srv.host.clone())
-                    } else {
-                        None
-                    }
+                    record
+                        .any()
+                        .downcast_ref::<DnsSrv>()
+                        .map(|srv| srv.host.clone())
                 })
                 .collect();
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1493,9 +1493,17 @@ impl Zeroconf {
         if let Some(records) = self.cache.get_srv(instance) {
             for record in records {
                 if let Some(srv) = record.any().downcast_ref::<DnsSrv>() {
-                    if self.cache.get_addr(&srv.host).is_none() {
-                        self.send_query_vec(&[(&srv.host, TYPE_A), (&srv.host, TYPE_AAAA)]);
-                        return true;
+                    match self.cache.get_addr(&srv.host) {
+                        Some(records) => {
+                            if records.is_empty() {
+                                self.send_query_vec(&[(&srv.host, TYPE_A), (&srv.host, TYPE_AAAA)]);
+                                return true;
+                            }
+                        }
+                        None => {
+                            self.send_query_vec(&[(&srv.host, TYPE_A), (&srv.host, TYPE_AAAA)]);
+                            return true;
+                        }
                     }
                 }
             }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -2238,7 +2238,7 @@ impl Zeroconf {
             let (hostnames, timers) = self.cache.refresh_due_hosts(ty_domain);
             for hostname in hostnames.iter() {
                 debug!("sending refresh queries for A and AAAA:  {}", hostname);
-                self.send_query_vec(&[(&hostname, TYPE_A), (&hostname, TYPE_AAAA)]);
+                self.send_query_vec(&[(hostname, TYPE_A), (hostname, TYPE_AAAA)]);
                 query_addr_count += 2;
             }
             new_timers.extend(timers);


### PR DESCRIPTION
I observed some resolving issues, when one stops a browse for a service after "ttl" expires and starts the same browse again. The info is never resolved, as the the query_unresolved process believes there are addresses cached, but actually the records are just empty.

Without this change and a responder that doesn't eagerly publish it's A / AAAA records, i always get a sad 🐼at the end. Using the the patched example query.rs like this. With the changes, the 🐼 is always happy.
```diff
diff --git a/examples/query.rs b/examples/query.rs
index 30339e6..8fc1425 100644
--- a/examples/query.rs
+++ b/examples/query.rs
@@ -13,6 +13,8 @@
 //!
 //! Keeps listening for new events.
 
+use std::time::Duration;
+
 use mdns_sd::{ServiceDaemon, ServiceEvent};
 
 fn main() {
@@ -51,8 +53,48 @@ fn main() {
                     println!(" Property: {}", prop);
                 }
             }
+            ServiceEvent::SearchStopped(_) => {
+                break;
+            }
             other_event => {
                 println!("At {:?} : {:?}", now.elapsed(), &other_event);
+                if now.elapsed() > Duration::from_secs(122) {
+                    mdns.stop_browse(&service_type).expect("To stop browsing");
+                }
+            }
+        }
+    }
+
+    let receiver2 = mdns.browse(&service_type).expect("Failed to browse 2");
+
+    while let Ok(event) = receiver2.recv() {
+        match event {
+            ServiceEvent::ServiceResolved(info) => {
+                println!(
+                    "2 At {:?}: Resolved a new service: {}\n host: {}\n port: {}",
+                    now.elapsed(),
+                    info.get_fullname(),
+                    info.get_hostname(),
+                    info.get_port(),
+                );
+                for addr in info.get_addresses().iter() {
+                    println!(" Address: {}", addr);
+                }
+                for prop in info.get_properties().iter() {
+                    println!(" Property: {}", prop);
+                }
+                println!("Did resolve, happy 🐼");
+                mdns.stop_browse(&service_type).expect("To stop browsing 2");
+            }
+            ServiceEvent::SearchStopped(_) => {
+                break;
+            }
+            other_event => {
+                if now.elapsed() > Duration::from_secs(130) {
+                    eprintln!("Did not resolve, sad 🐼");
+                    break;
+                }
+                println!("At {:?} : {:?}", now.elapsed(), &other_event);
             }
         }
     }
```