### PR TITLE
Change intf_socks to a map of (Interface, Socket)

### DIFF
--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1475,8 +1475,7 @@ impl Zeroconf {
         // If sz is 0, it means sock reached End-of-File.
         if sz == 0 {
             error!("socket {:?} was likely shutdown", sock);
-            let inmut_sock: &Socket = sock;
-            if let Err(e) = self.poller.delete(inmut_sock) {
+            if let Err(e) = self.poller.delete(&*sock) {
                 error!("failed to remove sock {:?} from poller: {}", sock, &e);
             }
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -455,7 +455,7 @@ impl ServiceDaemon {
                     .poller
                     .modify(&intf_sock.sock, polling::Event::readable(ev.key))
                 {
-                    error!("modify poller for IP {}: {}", &intf.ip(), e);
+                    error!("modify poller for interface {:?}: {}", &intf, e);
                     break;
                 }
             }
@@ -956,6 +956,7 @@ impl Zeroconf {
     fn new(signal_sock: UdpSocket, poller: Poller) -> Self {
         // Get interfaces.
         let my_ifaddrs = my_ip_interfaces();
+
         // Create a socket for every IP addr.
         // Note: it is possible that `my_ifaddrs` contains duplicated IP addrs.
         let mut intf_socks = HashMap::new();

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -29,7 +29,6 @@ fn integration_success() {
     let mut unique_intf_idx_ip_ver_set = HashSet::new();
     let mut non_idx_count = 0;
     for intf in all_interfaces.iter() {
-        // println!("intf:: {:?}", intf);
         let ip_ver = match intf.addr {
             IfAddr::V4(_) => 4u8,
             IfAddr::V6(_) => 6u8,
@@ -42,10 +41,6 @@ fn integration_success() {
             non_idx_count += 1;
         }
     }
-    println!(
-        "unique intf with index: {} non idx count: {non_idx_count}",
-        unique_intf_idx_ip_ver_set.len()
-    );
     let unique_intf_idx_ip_ver_count = unique_intf_idx_ip_ver_set.len() + non_idx_count;
 
     let ifaddrs_set: HashSet<_> = all_interfaces.iter().map(|intf| intf.ip()).collect();

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -29,7 +29,7 @@ fn integration_success() {
     let mut unique_intf_idx_ip_ver_set = HashSet::new();
     let mut non_idx_count = 0;
     for intf in all_interfaces.iter() {
-        println!("intf:: {:?}", intf);
+        // println!("intf:: {:?}", intf);
         let ip_ver = match intf.addr {
             IfAddr::V4(_) => 4u8,
             IfAddr::V6(_) => 6u8,


### PR DESCRIPTION
This is triggered by a test failure in the `integration_success` test case on macOS locally. It turns out that macOS could have two network interfaces on the same IPv6 address. 

```
intf:: Interface { name: "awdl0", 
addr: V6(Ifv6Addr { ip: fe80::f000:4aff:fe03:6c4c, netmask: ffff:ffff:ffff:ffff::, broadcast: None }), 
index: Some(13) }

intf:: Interface { name: "llw0", 
addr: V6(Ifv6Addr { ip: fe80::f000:4aff:fe03:6c4c, netmask: ffff:ffff:ffff:ffff::, broadcast: None }), 
index: Some(14) }
```

(According to chatGPT, `awdl` stands for Apple Wireless Direct Link, and `llw` stands for Low-Latency Wi-Fi)

But their interface index (i.e. scope_id in IPv6) are different.

As `Zeroconf.intf_socks` uses IP address as its key, these two interfaces are merged into a single entry in the `intf_socks` map, and later failed the test when checking `metrics["unregister-resend"]`. 

This patch is to use `Interface` as the key instead to identify each interface even when they share the same IPv6 address. Also simplify the value type to be `Socket` instead of `struct IntfSock`.
