### PR TITLE
cache flush: add missing timer for updated expires

### DIFF
--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1718,7 +1718,7 @@ impl Zeroconf {
         let mut changes = Vec::new();
         let mut timers = Vec::new();
         for record in msg.answers {
-            match self.cache.add_or_update(record) {
+            match self.cache.add_or_update(record, &mut timers) {
                 Some((dns_record, true)) => {
                     timers.push(dns_record.get_record().get_expire_time());
                     timers.push(dns_record.get_record().get_refresh_time());


### PR DESCRIPTION
In cache flush, a timer is needed if we want to make sure the "old" record gets removed at its new expire time. I suspect this might be the reason for some intermittent failures in CI, like [this one](https://github.com/keepsimple1/mdns-sd/actions/runs/10446384640/job/28923720348). 

This patch is to add the missing timer for such cases.