### PR TITLE
Send SearchStarted events with addrs as `ip (intf-name)` 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default = ["async", "logging"]
 
 [dependencies]
 flume = { version = "0.11", default-features = false } # channel between threads
-if-addrs = { version = "0.10", features = ["link-local"] } # get local IP addresses
+if-addrs = { version = "0.13", features = ["link-local"] } # get local IP addresses
 log = { version = "0.4", optional = true }             # logging
 polling = "2.1"                                        # select/poll sockets
 socket2 = { version = "0.5.5", features = ["all"] }      # socket APIs

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -52,7 +52,7 @@ fn main() {
                 }
             }
             other_event => {
-                println!("At {:?} : {:?}", now.elapsed(), &other_event);
+                println!("At {:?}: {:?}", now.elapsed(), &other_event);
             }
         }
     }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -2038,7 +2038,7 @@ impl Zeroconf {
         next_delay: u32,
         listener: Sender<ServiceEvent>,
     ) {
-        let pretty_interfaces: Vec<String> = self
+        let pretty_addrs: Vec<String> = self
             .intf_socks
             .keys()
             .map(|itf| format!("{} ({})", itf.ip(), itf.name))
@@ -2047,7 +2047,7 @@ impl Zeroconf {
         if let Err(e) = listener.send(ServiceEvent::SearchStarted(format!(
             "{} on addrs [{}]",
             &ty,
-            pretty_interfaces.join(", ")
+            pretty_addrs.join(", ")
         ))) {
             error!(
                 "Failed to send SearchStarted({})(repeating:{}): {}",

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -2038,10 +2038,16 @@ impl Zeroconf {
         next_delay: u32,
         listener: Sender<ServiceEvent>,
     ) {
-        let addr_list: Vec<_> = self.intf_socks.keys().map(|itf| itf.addr.ip()).collect();
+        let pretty_interfaces: Vec<String> = self
+            .intf_socks
+            .keys()
+            .map(|itf| format!("{} ({})", itf.ip(), itf.name))
+            .collect();
+
         if let Err(e) = listener.send(ServiceEvent::SearchStarted(format!(
-            "{} on addrs {:?}",
-            &ty, &addr_list
+            "{} on addrs [{}]",
+            &ty,
+            pretty_interfaces.join(", ")
         ))) {
             error!(
                 "Failed to send SearchStarted({})(repeating:{}): {}",

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -2038,7 +2038,7 @@ impl Zeroconf {
         next_delay: u32,
         listener: Sender<ServiceEvent>,
     ) {
-        let addr_list: Vec<_> = self.intf_socks.keys().collect();
+        let addr_list: Vec<_> = self.intf_socks.keys().map(|itf| itf.addr.ip()).collect();
         if let Err(e) = listener.send(ServiceEvent::SearchStarted(format!(
             "{} on addrs {:?}",
             &ty, &addr_list


### PR DESCRIPTION
Otherwise the output gets pretty cluttered when running the query example

With the change to Map(Interface, Socket) in #242 
The outpout looks a bit odd and too verbose when expecting addrs:
```
cargo run --example=query _services._dns-sd._udp
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.31s
     Running `target/debug/examples/query _services._dns-sd._udp`
At 1.320972ms : SearchStarted("_services._dns-sd._udp.local. on addrs [Interface { name: \"br-1a301212c996\", addr: V4(Ifv4Addr { ip: 192.168.49.1, netmask: 255.255.255.0, broadcast: Some(192.168.49.255) }), index: Some(3) }, Interface { name: \"ens33\", addr: V4(Ifv4Addr { ip: 192.168.178.80, netmask: 255.255.255.0, broadcast: Some(192.168.178.255) }), index: Some(2) }, Interface { name: \"ens33\", addr: V6(Ifv6Addr { ip: fe80::c9f4:d01d:e4ca:1296, netmask: ffff:ffff:ffff:ffff::, broadcast: None }), index: Some(2) }, Interface { name: \"docker0\", addr: V4(Ifv4Addr { ip: 172.17.0.1, netmask: 255.255.0.0, broadcast: Some(172.17.255.255) }), index: Some(4) }, Interface { name: \"ens33\", addr: V6(Ifv6Addr { ip: 2003:e8:bf4e:c900:9553:51cc:c0bc:34b9, netmask: ffff:ffff:ffff:ffff::, broadcast: None }), index: Some(2) }, Interface { name: \"ens33\", addr: V6(Ifv6Addr { ip: 2003:e8:bf4e:c900:f1a9:80a6:bdf6:5311, netmask: ffff:ffff:ffff:ffff::, broadcast: None }), index: Some(2) }]")
```

This change brings back the output like it was before:

```
cargo run --example=query _services._dns-sd._udp
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/examples/query _services._dns-sd._udp`
At 1.107118ms : SearchStarted("_services._dns-sd._udp.local. on addrs [172.17.0.1, 192.168.178.80, 2003:e8:bf4e:c900:9553:51cc:c0bc:34b9, 192.168.49.1, 2003:e8:bf4e:c900:f1a9:80a6:bdf6:5311, fe80::c9f4:d01d:e4ca:1296]")
```

**Update** to `<ip> (<intf-name>)`, where i also aligned the query example output of other events with ServiceResolved()
```
At 1.074132ms: SearchStarted("_fbox._tcp.local. on addrs [192.168.73.130 (eno16777736), 192.168.178.76 (eno33554984), fe80::e389:cd5c:6aa4:50e3 (eno33554984), fe80::f3fc:8e58:38e3:ff2b (eno16777736), 2003:e8:bf4e:c900:4f05:cc9:27e5:48f3 (eno33554984)]")
````
