### PR TITLE
DnsTxt debug print: make its text field human-readable

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -528,7 +528,11 @@ impl DnsRecordExt for DnsTxt {
 impl fmt::Debug for DnsTxt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let properties = decode_txt(&self.text);
-        write!(f, "DnsTxt {{ record: {:?}, text: {:?} }}", self.record, properties)
+        write!(
+            f,
+            "DnsTxt {{ record: {:?}, text: {:?} }}",
+            self.record, properties
+        )
     }
 }
 

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -6,7 +6,7 @@
 
 #[cfg(feature = "logging")]
 use crate::log::debug;
-use crate::{Error, Result, ServiceInfo};
+use crate::{service_info::decode_txt, Error, Result, ServiceInfo};
 use if_addrs::Interface;
 use std::{
     any::Any,
@@ -482,7 +482,7 @@ impl DnsRecordExt for DnsSrv {
 //    marks).  Everything up to the first '=' character is the key (Section
 //    6.4).  Everything after the first '=' character to the end of the
 //    string (including subsequent '=' characters, if any) is the value
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct DnsTxt {
     pub(crate) record: DnsRecord,
     pub(crate) text: Vec<u8>,
@@ -522,6 +522,13 @@ impl DnsRecordExt for DnsTxt {
 
     fn clone_box(&self) -> Box<dyn DnsRecordExt> {
         Box::new(self.clone())
+    }
+}
+
+impl fmt::Debug for DnsTxt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let properties = decode_txt(&self.text);
+        write!(f, "DnsTxt {{ record: {:?}, text: {:?} }}", self.record, properties)
     }
 }
 

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -1,3 +1,5 @@
+//! Define `ServiceInfo` to represent a service and its operations.
+
 #[cfg(feature = "logging")]
 use crate::log::error;
 use crate::{dns_parser::split_sub_domain, Error, Result};
@@ -652,7 +654,7 @@ fn encode_txt<'a>(properties: impl Iterator<Item = &'a TxtProperty>) -> Vec<u8> 
 }
 
 // Convert from DNS TXT record content to key/value pairs
-fn decode_txt(txt: &[u8]) -> Vec<TxtProperty> {
+pub(crate) fn decode_txt(txt: &[u8]) -> Vec<TxtProperty> {
     let mut properties = Vec::new();
     let mut offset = 0;
     while offset < txt.len() {


### PR DESCRIPTION
This is to address issue #243 . With the changes, its debug print looks like this:

`[2024-08-21T04:11:24Z DEBUG mdns_sd::dns_parser] add_answer push: DnsTxt { record: DnsRecord { entry: DnsEntry { name: "test7._my-log._udp.local.", ty: 16, class: 1, cache_flush: true }, ttl: 4500, created: 1724213484072, expires: 1724217984072, refresh: 1724217084072 }, text: [TxtProperty {key: "PATH", val: Some("one")}] }`

