### PR TITLE
remove fastrand dependency from dev-test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ socket2 = { version = "0.5.5", features = ["all"] }      # socket APIs
 
 [dev-dependencies]
 env_logger = { version = "= 0.10.2", default-features = false, features= ["humantime"] }
-fastrand = "1.8"
 rand ="0.8"
 test-log = "= 0.2.14"
 test-log-macros = "= 0.2.14"

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -3,6 +3,7 @@ use mdns_sd::{
     DaemonEvent, DaemonStatus, HostnameResolutionEvent, IfKind, IntoTxtProperties, ServiceDaemon,
     ServiceEvent, ServiceInfo, UnregisterStatus,
 };
+use rand::Rng;
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::thread::sleep;
@@ -957,7 +958,8 @@ fn instance_name_two_dots() {
 
 fn my_ip_interfaces() -> Vec<Interface> {
     // Use a random port for binding test.
-    let test_port = fastrand::u16(8000u16..9000u16);
+    let mut rng = rand::thread_rng();
+    let test_port = rng.gen_range(8000u16..9000u16);
 
     if_addrs::get_if_addrs()
         .unwrap_or_default()


### PR DESCRIPTION
no need to use both `fastrand` and `rand`. Both should work and I chose to use `rand` as it's more common. The size of the crate is less important as it's only used in the tests.

Also refactored a bit `read_name` without changing the logic.