### PR TITLE
add --verbose in CI test run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: Run tests with debugs
         if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
-        run: RUST_LOG=debug cargo test
+        run: RUST_LOG=debug cargo test --verbose
       - name: Run tests on Windows
         if: matrix.os == 'windows-latest'
         run: cargo test

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -1278,7 +1278,7 @@ impl DnsIncoming {
         // RFC 1035: https://datatracker.ietf.org/doc/html/rfc1035#section-3.2.1
         //
         // All RRs have the same top level format shown below:
-        //         1  1  1  1  1  1
+        //                               1  1  1  1  1  1
         // 0  1  2  3  4  5  6  7  8  9  0  1  2  3  4  5
         // +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
         // |                                               |


### PR DESCRIPTION
This is to help debugging issue #253 .

I cannot figure out yet how to get a stack trace when the problematic unit test stuck. This patch is trying to see if `--verbose` will help or not.

Also fixed a formatting issue in one of the comments.