### PR TITLE
bump up version to 0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# Version 0.11.4 (2024-09-10)
+
+Bugfixes. Added checks for corrupted RR data to prevent unnecessary panics. Thanks for new 
+contributor @rise0chen !
+
+Sorry that this release has a few merged small commits as I didn't know how to properly
+merge in a PR that targets a fetaure branch used in another PR, instead of `main` branch.
+
+## All changes
+
+* e54485e add --verbose in CI test run (#254) (keepsimple1)
+* f0c4c27 remove fastrand dependency from dev-test (#252) (keepsimple1)
+* dff1596 Merge pull request #250 from keepsimple1/rdata-check (keepsimple1)
+* 659e684 fix cargo clippy warning (keepsimple1)
+* 90a2f12 Merge pull request #251 from rise0chen/rdata-check (keepsimple1)
+* 6d51f55 Merge branch 'rdata-check' into rdata-check (keepsimple1)
+* 1b2cf40 add a check for rr data len (keepsimple1)
+* a5de799 feat: test random data (rise0chen)
+* 40698a3 add test case and simplify DnsTxt::new (keepsimple1)
+* fc489bd refactoring error log (keepsimple1)
+* a3fad8e add a check for rr data len (keepsimple1)
+
 # Version 0.11.3 (2024-08-23)
 
 A release of bugfixes and refactorings.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdns-sd"
-version = "0.11.3"
+version = "0.11.4"
 authors = ["keepsimple <keepsimple@gmail.com>"]
 edition = "2018"
 rust-version = "1.63.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ socket2 = { version = "0.5.5", features = ["all"] }      # socket APIs
 
 [dev-dependencies]
 env_logger = { version = "= 0.10.2", default-features = false, features= ["humantime"] }
+humantime = "2.1"
 rand ="0.8"
 test-log = "= 0.2.14"
 test-log-macros = "= 0.2.14"

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1199,8 +1199,8 @@ fn test_cache_flush_record() {
         match event {
             ServiceEvent::ServiceResolved(info) => {
                 resolved = true;
-                println!("Resolved a service of {}", &info.get_fullname());
-                println!("JLN service: {:?}", info);
+                timed_println(format!("Resolved a service of {}", &info.get_fullname()));
+                timed_println(format!("JLN service: {:?}", info));
                 break;
             }
             e => {
@@ -1233,10 +1233,10 @@ fn test_cache_flush_record() {
         &properties[..],
     )
     .unwrap();
-    let result = server.register(my_service.clone());
+    let result = server.register(my_service);
     assert!(result.is_ok());
 
-    println!("Re-registered with updated IPv4 addr: {}", &service_ip_addr);
+    timed_println(format!("Re-registered with updated IPv4 addr: {}", &service_ip_addr));
 
     // Wait for the new registration sent out and cache flushed.
     sleep(Duration::from_secs(2));
@@ -1249,7 +1249,7 @@ fn test_cache_flush_record() {
             ServiceEvent::ServiceResolved(info) => {
                 // Verify the address flushed and updated.
                 let new_addrs = info.get_addresses();
-                println!("new address resolved: {:?}", new_addrs);
+                timed_println(format!("new address resolved: {:?}", new_addrs));
                 if new_addrs.len() == 1 {
                     let first_addr = new_addrs.iter().next().unwrap();
                     assert_eq!(first_addr, &service_ip_addr);
@@ -1258,7 +1258,7 @@ fn test_cache_flush_record() {
                 }
             }
             e => {
-                println!("Received event {:?}", e);
+                timed_println(format!("Received event {:?}", e));
             }
         }
     }
@@ -1449,4 +1449,11 @@ fn test_domain_suffix_in_browse() {
     assert!(mdns_client.browse("_service-name._tcp.local").is_err());
     assert!(mdns_client.browse("_service-name._tcp.local.").is_ok());
     mdns_client.shutdown().unwrap();
+}
+
+/// A helper function to include a timestamp for println.
+fn timed_println(msg: String) {
+    let now = SystemTime::now();
+    let formatted_time = humantime::format_rfc3339(now);
+    println!("[{}] {}", formatted_time, msg);
 }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1236,7 +1236,10 @@ fn test_cache_flush_record() {
     let result = server.register(my_service);
     assert!(result.is_ok());
 
-    timed_println(format!("Re-registered with updated IPv4 addr: {}", &service_ip_addr));
+    timed_println(format!(
+        "Re-registered with updated IPv4 addr: {}",
+        &service_ip_addr
+    ));
 
     // Wait for the new registration sent out and cache flushed.
     sleep(Duration::from_secs(2));


### PR DESCRIPTION
Added timestamped prints in a test to help debugging an intermittent test failure only seen on GitHub CI.