### PR TITLE
dev-test: back to using fastrand crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ socket2 = { version = "0.5.5", features = ["all"] }      # socket APIs
 
 [dev-dependencies]
 env_logger = { version = "= 0.10.2", default-features = false, features= ["humantime"] }
+fastrand = "2.1"
 humantime = "2.1"
-rand ="0.8"
 test-log = "= 0.2.14"
 test-log-macros = "= 0.2.14"

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -1634,6 +1634,8 @@ const fn get_expiration_time(created: u64, ttl: u32, percent: u32) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use std::iter::repeat_with;
+
     use super::{
         current_time_millis, get_expiration_time, DnsIncoming, DnsNSec, DnsOutgoing, DnsPointer,
         DnsRecordExt, DnsSrv, DnsTxt, CLASS_CACHE_FLUSH, CLASS_IN, FLAGS_QR_QUERY,
@@ -1770,24 +1772,18 @@ mod tests {
 
     #[test]
     fn test_rr_rand_data_error() {
-        use rand::prelude::*;
-
         const DATA_LEN_MAX: usize = 2048;
         const TEST_TIMES: usize = 100000;
 
-        let mut rng = rand::thread_rng();
-        let mut rand_data: Vec<u8> = Vec::with_capacity(DATA_LEN_MAX);
-
         for _ in 0..TEST_TIMES {
             // Generate a random length of data
-            let data_len: usize = rng.gen_range(0..DATA_LEN_MAX);
-            rand_data.resize(data_len, 0);
+            let data_len = fastrand::usize(0..DATA_LEN_MAX);
 
             // Generate random data
-            rng.fill(rand_data.as_mut_slice());
+            let rand_data: Vec<u8> = repeat_with(|| fastrand::u8(..)).take(data_len).collect();
 
             // Decode rand data, it should not panic
-            let _ = DnsIncoming::new(rand_data.clone());
+            let _ = DnsIncoming::new(rand_data);
         }
     }
 

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -3,7 +3,6 @@ use mdns_sd::{
     DaemonEvent, DaemonStatus, HostnameResolutionEvent, IfKind, IntoTxtProperties, ServiceDaemon,
     ServiceEvent, ServiceInfo, UnregisterStatus,
 };
-use rand::Rng;
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::thread::sleep;
@@ -958,8 +957,7 @@ fn instance_name_two_dots() {
 
 fn my_ip_interfaces() -> Vec<Interface> {
     // Use a random port for binding test.
-    let mut rng = rand::thread_rng();
-    let test_port = rng.gen_range(8000u16..9000u16);
+    let test_port = fastrand::u16(8000u16..9000u16);
 
     if_addrs::get_if_addrs()
         .unwrap_or_default()


### PR DESCRIPTION
The main reason is that `rand` brought many more dependencies in, even thought it's dev-test. And it turns out, using `fastrand` also reduces code in the test itself.