### PR TITLE
tests: fix remove addr test

### DIFF
--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1330,7 +1330,7 @@ fn test_cache_flush_remove_one_addr() {
 
     // Stop browsing for a moment.
     client.stop_browse(service).unwrap();
-    sleep(Duration::from_secs(1));
+    sleep(Duration::from_secs(2)); // Wait 1 more second for the 2nd annoucement
 
     // Re-register the service to have only 1 addr.
     my_service =


### PR DESCRIPTION
This is to fix a test failure seen in [CI run](https://github.com/keepsimple1/mdns-sd/actions/runs/10865084060/job/30151121329). 