### PR TITLE
register service: apply interface selection for auto IP addr

### DIFF
--- a/examples/register.rs
+++ b/examples/register.rs
@@ -10,8 +10,9 @@
 //!
 //! Options:
 //! "--unregister": automatically unregister after 2 seconds.
+//! "--disable-ipv6": not to use IPv6 interfaces.
 
-use mdns_sd::{DaemonEvent, ServiceDaemon, ServiceInfo};
+use mdns_sd::{DaemonEvent, IfKind, ServiceDaemon, ServiceInfo};
 use std::{env, thread, time::Duration};
 
 fn main() {
@@ -20,14 +21,23 @@ fn main() {
     // Simple command line options.
     let args: Vec<String> = env::args().collect();
     let mut should_unreg = false;
+    let mut disable_ipv6 = false;
+
     for arg in args.iter() {
         if arg.as_str() == "--unregister" {
             should_unreg = true
+        } else if arg.as_str() == "--disable-ipv6" {
+            disable_ipv6 = true
         }
     }
 
     // Create a new mDNS daemon.
     let mdns = ServiceDaemon::new().expect("Could not create service daemon");
+
+    if disable_ipv6 {
+        mdns.disable_interface(IfKind::IPv6).unwrap();
+    }
+
     let service_type = match args.get(1) {
         Some(arg) => format!("{}.local.", arg),
         None => {

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -2510,7 +2510,7 @@ fn check_service_name(fullname: &str) -> Result<()> {
 /// Validate a hostname.
 fn check_hostname(hostname: &str) -> Result<()> {
     if !hostname.ends_with(".local.") {
-        return Err(e_fmt!("Hostname must end with '.local.'"));
+        return Err(e_fmt!("Hostname must end with '.local.': {hostname}"));
     }
 
     if hostname == ".local." {


### PR DESCRIPTION
From the logs in this [discussion](https://github.com/keepsimple1/mdns-sd/discussions/260#discussioncomment-10864226), it seems that we are not apply interface selections for IP address when registering a service using addr_auto.  The interface selection was only applied for interface monitoring & polling.  

This patch is to fix that. To test it, I added a new option `--disable-ipv6` to the sample program `register`.