### PR TITLE
feat: verify to support Cache Flush on Failure Indication

### DIFF
--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -243,6 +243,7 @@ impl DnsCache {
                 let expired = addr.get_record().is_expired(now);
                 if expired {
                     if let Some(addr_record) = addr.any().downcast_ref::<DnsAddress>() {
+                        debug!("evict expired ADDR: {:?}", addr_record);
                         removed
                             .entry(addr.get_name().to_string())
                             .or_insert_with(HashSet::new)

--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -449,6 +449,28 @@ impl DnsCache {
             .collect()
     }
 
+    /// Set SRV records with `instance_name` to expire at `expire_at` if it is
+    /// sooner than the current expire time.
+    pub(crate) fn expire_srv(&mut self, instance_name: &str, expire_at: u64) {
+        for record in self.srv.get_mut(instance_name).into_iter().flatten() {
+            let current_expire = record.get_expire();
+            if expire_at < current_expire {
+                record.set_expire(expire_at);
+            }
+        }
+    }
+
+    /// Set ADDR records with `hostname` to expire at `expire_at` if it is
+    /// sooner than the current expire time.
+    pub(crate) fn expire_addr(&mut self, hostname: &str, expire_at: u64) {
+        for record in self.addr.get_mut(hostname).into_iter().flatten() {
+            let current_expire = record.get_expire();
+            if expire_at < current_expire {
+                record.set_expire(expire_at);
+            }
+        }
+    }
+
     /// Returns a list of Known Answer for a given question of `name` with `qtype`.
     /// The timestamp `now` is passed in to check TTL.
     ///

--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -108,8 +108,11 @@ impl DnsCache {
             .collect()
     }
 
-    /// Returns a list of resource records (name, rr_type) that need to flush (verify).
-    pub(crate) fn service_flush(
+    /// Returns a list of resource records (name, rr_type) that need to be queried in order to
+    /// verify the `instance`.
+    ///
+    /// If `expire_at` is not None, the resource records' expire time will be updated.
+    pub(crate) fn service_verify_queries(
         &mut self,
         instance: &str,
         expire_at: Option<u64>,

--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -456,6 +456,10 @@ impl DnsCache {
             let current_expire = record.get_expire();
             if expire_at < current_expire {
                 record.set_expire(expire_at);
+                debug!(
+                    "set SRV {} record expires at {expire_at}",
+                    record.get_name()
+                );
             }
         }
     }
@@ -467,6 +471,10 @@ impl DnsCache {
             let current_expire = record.get_expire();
             if expire_at < current_expire {
                 record.set_expire(expire_at);
+                println!(
+                    "set ADDR {} record expires at {expire_at}",
+                    record.get_name()
+                );
             }
         }
     }

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -378,6 +378,13 @@ pub(crate) trait DnsRecordExt: fmt::Debug {
         self.get_record_mut().set_expire(expire_at);
     }
 
+    /// Set expire as `expire_at` if it is sooner than the current `expire`.
+    fn set_expire_sooner(&mut self, expire_at: u64) {
+        if expire_at < self.get_expire() {
+            self.get_record_mut().set_expire(expire_at);
+        }
+    }
+
     /// Given `now`, if the record is due to refresh, this method updates the refresh time
     /// and returns the new refresh time. Otherwise, returns None.
     fn updated_refresh_time(&mut self, now: u64) -> Option<u64> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,8 +157,8 @@ pub use dns_parser::{
 };
 pub use error::{Error, Result};
 pub use service_daemon::{
-    DaemonEvent, DaemonStatus, DnsNameChange, HostnameResolutionEvent, IfKind, Metrics,
-    ServiceDaemon, ServiceEvent, UnregisterStatus, SERVICE_NAME_LEN_MAX_DEFAULT,
+    DaemonEvent, DaemonStatus, DnsNameChange, DnsResource, HostnameResolutionEvent, IfKind,
+    Metrics, ServiceDaemon, ServiceEvent, UnregisterStatus, SERVICE_NAME_LEN_MAX_DEFAULT,
 };
 pub use service_info::{AsIpAddrs, IntoTxtProperties, ServiceInfo, TxtProperties, TxtProperty};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,8 +157,8 @@ pub use dns_parser::{
 };
 pub use error::{Error, Result};
 pub use service_daemon::{
-    DaemonEvent, DaemonStatus, DnsNameChange, DnsResource, HostnameResolutionEvent, IfKind,
-    Metrics, ServiceDaemon, ServiceEvent, UnregisterStatus, SERVICE_NAME_LEN_MAX_DEFAULT,
+    DaemonEvent, DaemonStatus, DnsNameChange, HostnameResolutionEvent, IfKind, Metrics,
+    ServiceDaemon, ServiceEvent, UnregisterStatus, SERVICE_NAME_LEN_MAX_DEFAULT,
     VERIFY_RESOURCE_TIMEOUT_DEFAULT,
 };
 pub use service_info::{AsIpAddrs, IntoTxtProperties, ServiceInfo, TxtProperties, TxtProperty};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ pub use error::{Error, Result};
 pub use service_daemon::{
     DaemonEvent, DaemonStatus, DnsNameChange, HostnameResolutionEvent, IfKind, Metrics,
     ServiceDaemon, ServiceEvent, UnregisterStatus, SERVICE_NAME_LEN_MAX_DEFAULT,
-    VERIFY_RESOURCE_TIMEOUT_DEFAULT,
+    VERIFY_TIMEOUT_DEFAULT,
 };
 pub use service_info::{AsIpAddrs, IntoTxtProperties, ServiceInfo, TxtProperties, TxtProperty};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,7 @@ pub use error::{Error, Result};
 pub use service_daemon::{
     DaemonEvent, DaemonStatus, DnsNameChange, DnsResource, HostnameResolutionEvent, IfKind,
     Metrics, ServiceDaemon, ServiceEvent, UnregisterStatus, SERVICE_NAME_LEN_MAX_DEFAULT,
+    VERIFY_RESOURCE_TIMEOUT_DEFAULT,
 };
 pub use service_info::{AsIpAddrs, IntoTxtProperties, ServiceInfo, TxtProperties, TxtProperty};
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -2667,18 +2667,19 @@ impl Zeroconf {
         };
 
         // send query for the resource records.
-        let resource_vec = self.cache.service_flush(&instance, expire_at);
+        let record_vec = self.cache.service_verify_queries(&instance, expire_at);
 
-        if !resource_vec.is_empty() {
-            let query_vec: Vec<(&str, u16)> = resource_vec
+        if !record_vec.is_empty() {
+            let query_vec: Vec<(&str, u16)> = record_vec
                 .iter()
                 .map(|(record, rr_type)| (record.as_str(), *rr_type))
                 .collect();
             self.send_query_vec(&query_vec);
 
-            // schedule a resend 1 second later
             if let Some(new_expire) = expire_at {
-                self.add_timer(new_expire);
+                self.add_timer(new_expire); // ensure a check for the new expire time.
+
+                // schedule a resend 1 second later
                 self.add_retransmission(now + 1000, Command::Verify(instance, timeout));
             }
         }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -69,9 +69,9 @@ macro_rules! e_fmt {
 /// [RFC 6763 section 7.2](https://www.rfc-editor.org/rfc/rfc6763#section-7.2).
 pub const SERVICE_NAME_LEN_MAX_DEFAULT: u8 = 15;
 
-/// The default time out for [ServiceDaemon::verify_resource] is 10 seconds, per
+/// The default time out for [ServiceDaemon::verify] is 10 seconds, per
 /// [RFC 6762 section 10.4](https://datatracker.ietf.org/doc/html/rfc6762#section-10.4)
-pub const VERIFY_RESOURCE_TIMEOUT_DEFAULT: Duration = Duration::from_secs(10);
+pub const VERIFY_TIMEOUT_DEFAULT: Duration = Duration::from_secs(10);
 
 const MDNS_PORT: u16 = 5353;
 const GROUP_ADDR_V4: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 251);
@@ -406,7 +406,7 @@ impl ServiceDaemon {
     ///
     /// This call will issue queries for a service instance's SRV record and Address records.
     ///
-    /// For `timeout`, most users should use [VERIFY_RESOURCE_TIMEOUT_DEFAULT]
+    /// For `timeout`, most users should use [VERIFY_TIMEOUT_DEFAULT]
     /// unless there is a reason not to follow RFC.
     ///
     /// If no response is received within `timeout`, the current resource
@@ -685,8 +685,8 @@ impl ServiceDaemon {
                 zc.process_set_option(daemon_opt);
             }
 
-            Command::Verify(resource, timeout) => {
-                zc.exec_command_verify_resource(resource, timeout, repeating);
+            Command::Verify(instance_fullname, timeout) => {
+                zc.exec_command_verify(instance_fullname, timeout, repeating);
             }
 
             _ => {
@@ -2649,12 +2649,7 @@ impl Zeroconf {
         self.increase_counter(Counter::RegisterResend, 1);
     }
 
-    fn exec_command_verify_resource(
-        &mut self,
-        instance: String,
-        timeout: Duration,
-        repeating: bool,
-    ) {
+    fn exec_command_verify(&mut self, instance: String, timeout: Duration, repeating: bool) {
         /*
         RFC 6762 section 10.4:
         ...

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -69,6 +69,10 @@ macro_rules! e_fmt {
 /// [RFC 6763 section 7.2](https://www.rfc-editor.org/rfc/rfc6763#section-7.2).
 pub const SERVICE_NAME_LEN_MAX_DEFAULT: u8 = 15;
 
+/// The default time out for [ServiceDaemon::verify_resource] is 10 seconds, per
+/// [RFC 6762 section 10.4](https://datatracker.ietf.org/doc/html/rfc6762#section-10.4)
+pub const VERIFY_RESOURCE_TIMEOUT_DEFAULT: Duration = Duration::from_secs(10);
+
 const MDNS_PORT: u16 = 5353;
 const GROUP_ADDR_V4: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 251);
 const GROUP_ADDR_V6: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0xfb);
@@ -401,8 +405,10 @@ impl ServiceDaemon {
     /// Proactively confirms whether a DNS resource record still valid.
     ///
     /// This call will issue two queries one second apart for `resource`.
+    /// For `timeout`, most users should use [VERIFY_RESOURCE_TIMEOUT_DEFAULT]
+    /// unless there is a reason not to follow RFC.
     ///
-    /// If no response is received within 10 seconds, the current resource
+    /// If no response is received within `timeout`, the current resource
     /// record will be flushed, and if needed, `ServiceRemoved` event will be
     /// sent to active queriers.
     ///

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -402,19 +402,20 @@ impl ServiceDaemon {
         )))
     }
 
-    /// Proactively confirms whether a DNS resource record still valid.
+    /// Proactively confirms whether a service instance still valid.
     ///
-    /// This call will issue two queries one second apart for `resource`.
+    /// This call will issue queries for a service instance's SRV record and Address records.
+    ///
     /// For `timeout`, most users should use [VERIFY_RESOURCE_TIMEOUT_DEFAULT]
     /// unless there is a reason not to follow RFC.
     ///
     /// If no response is received within `timeout`, the current resource
-    /// record will be flushed, and if needed, `ServiceRemoved` event will be
+    /// records will be flushed, and if needed, `ServiceRemoved` event will be
     /// sent to active queriers.
     ///
     /// Reference: [RFC 6762](https://datatracker.ietf.org/doc/html/rfc6762#section-10.4)
-    pub fn verify_resource(&self, service_instance: String, timeout: Duration) -> Result<()> {
-        self.send_cmd(Command::Verify(service_instance, timeout))
+    pub fn verify(&self, instance_fullname: String, timeout: Duration) -> Result<()> {
+        self.send_cmd(Command::Verify(instance_fullname, timeout))
     }
 
     fn daemon_thread(signal_sock: UdpSocket, poller: Poller, receiver: Receiver<Command>) {

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -3581,8 +3581,8 @@ mod tests {
         // Shutdown the server so no more responses / refreshes for addresses.
         server.shutdown().unwrap();
 
-        // Wait till hostname address record expires.
-        let timeout = Duration::from_secs(addr_ttl as u64);
+        // Wait till hostname address record expires, with 1 second grace period.
+        let timeout = Duration::from_secs(addr_ttl as u64 + 1);
         let removed = loop {
             match event_receiver.recv_timeout(timeout) {
                 Ok(HostnameResolutionEvent::AddressesRemoved(removed_host, addresses)) => {

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1908,15 +1908,20 @@ fn test_verify_addr() {
         )
         .unwrap();
     let timeout = Duration::from_secs(4);
+    let mut service_removed = false;
 
     while let Ok(event) = receiver.recv_timeout(timeout) {
         match event {
             ServiceEvent::ServiceRemoved(service_type, fullname) => {
                 println!("service removed: {service_type} : {fullname}");
+                service_removed = true;
+                break;
             }
             _ => {}
         }
     }
+
+    assert!(service_removed);
 }
 
 /// A helper function to include a timestamp for println.

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1831,9 +1831,7 @@ fn test_verify_srv() {
     sleep(Duration::from_secs(1));
 
     // check `ServiceRemoved`
-    client
-        .verify_resource(fullname, Duration::from_secs(3))
-        .unwrap();
+    client.verify(fullname, Duration::from_secs(3)).unwrap();
     let timeout = Duration::from_secs(4);
     let mut service_removal = false;
 

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1,7 +1,7 @@
 use if_addrs::{IfAddr, Interface};
 use mdns_sd::{
-    DaemonEvent, DaemonStatus, HostnameResolutionEvent, IfKind, IntoTxtProperties, ServiceDaemon,
-    ServiceEvent, ServiceInfo, UnregisterStatus,
+    DaemonEvent, DaemonStatus, DnsResource, HostnameResolutionEvent, IfKind, IntoTxtProperties,
+    ServiceDaemon, ServiceEvent, ServiceInfo, UnregisterStatus,
 };
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -1778,6 +1778,145 @@ fn test_name_conflict_3() {
 
     // Verify that we have resolve two services instead of one.
     assert_eq!(service_names.len(), 3);
+}
+
+#[test]
+fn test_verify_srv() {
+    // start a server
+    let ty_domain = "_verify-srv._udp.local.";
+    let host_name = "verify_srv.local.";
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap();
+    let instance_name = now.as_micros().to_string(); // Create a unique name.
+    let port = 5200;
+
+    // Get a single IPv4 address
+    let ip_addr1 = my_ip_interfaces()
+        .iter()
+        .find(|iface| iface.ip().is_ipv4())
+        .map(|iface| iface.ip())
+        .unwrap();
+
+    // Register the service.
+    let service1 = ServiceInfo::new(ty_domain, &instance_name, host_name, &ip_addr1, port, None)
+        .expect("valid service info");
+    let fullname = service1.get_fullname().to_string();
+
+    let server1 = ServiceDaemon::new().expect("failed to start server");
+    server1
+        .register(service1)
+        .expect("Failed to register service1");
+
+    // wait for the service announced.
+    sleep(Duration::from_secs(1));
+
+    // start a client
+    let client = ServiceDaemon::new().expect("failed to start client");
+    let receiver = client.browse(ty_domain).unwrap();
+    let timeout = Duration::from_secs(2);
+
+    while let Ok(event) = receiver.recv_timeout(timeout) {
+        match event {
+            ServiceEvent::ServiceResolved(info) => {
+                println!("service resolved: {:?}", info);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    // kill the server without unregister (i.e. not-graceful-shutdown)
+    server1.shutdown().unwrap();
+    sleep(Duration::from_secs(1));
+
+    // check `ServiceRemoved`
+    client
+        .verify_resource(DnsResource::Srv(fullname), Duration::from_secs(3))
+        .unwrap();
+    let timeout = Duration::from_secs(4);
+    let mut service_removal = false;
+
+    while let Ok(event) = receiver.recv_timeout(timeout) {
+        match event {
+            ServiceEvent::ServiceRemoved(service_type, fullname) => {
+                service_removal = true;
+                println!("service removed: {service_type} : {fullname}");
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    assert!(service_removal);
+}
+
+#[test]
+fn test_verify_addr() {
+    // start a server
+    let ty_domain = "_verify-addr._udp.local.";
+    let host_name = "verify_addr.local.";
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap();
+    let instance_name = now.as_micros().to_string(); // Create a unique name.
+    let port = 5200;
+
+    // Get a single IPv4 address
+    let ip_addr1 = my_ip_interfaces()
+        .iter()
+        .find(|iface| iface.ip().is_ipv4())
+        .map(|iface| iface.ip())
+        .unwrap();
+
+    // Register the service.
+    let service1 = ServiceInfo::new(ty_domain, &instance_name, host_name, &ip_addr1, port, None)
+        .expect("valid service info");
+
+    let server1 = ServiceDaemon::new().expect("failed to start server");
+    server1
+        .register(service1)
+        .expect("Failed to register service1");
+
+    // wait for the service announced.
+    sleep(Duration::from_secs(1));
+
+    // start a client
+    let client = ServiceDaemon::new().expect("failed to start client");
+    let receiver = client.browse(ty_domain).unwrap();
+    let timeout = Duration::from_secs(2);
+
+    while let Ok(event) = receiver.recv_timeout(timeout) {
+        match event {
+            ServiceEvent::ServiceResolved(info) => {
+                println!("service resolved: {:?}", info);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    // kill the server without unregister (i.e. not-graceful-shutdown)
+    server1.shutdown().unwrap();
+    sleep(Duration::from_secs(1));
+
+    // check `ServiceRemoved`
+    client
+        .verify_resource(
+            DnsResource::Addr(host_name.to_string()),
+            Duration::from_secs(3),
+        )
+        .unwrap();
+    let timeout = Duration::from_secs(4);
+
+    while let Ok(event) = receiver.recv_timeout(timeout) {
+        match event {
+            ServiceEvent::ServiceRemoved(service_type, fullname) => {
+                println!("service removed: {service_type} : {fullname}");
+            }
+            _ => {}
+        }
+    }
 }
 
 /// A helper function to include a timestamp for println.


### PR DESCRIPTION
This patch is to resolve issue #54 by implement a function to support [Cache Flush on Failure Indication](https://datatracker.ietf.org/doc/html/rfc6762#section-10.4) 

A new API of `ServiceDaemon` is added:

```
    pub fn verify_resource(&self, resource: DnsResource, timeout: Duration) -> Result<()>
```
The idea is that, a querier can call this API anytime to verify if the service records still valid. A `ServiceRemoved` event will be triggered if no response in `timeout`.

`DnsResource` supports `SRV` record and `ADDR` record at this moment.

For convenience, `VERIFY_RESOURCE_TIMEOUT_DEFAULT` is defined for `timeout`. 

UPDATE: 

I simplified the new API based on this thought: (most) users would not make 2 calls to verify `service_instance_name` and `hostname`  for one service instance.  The user should be able to call just once to verify a service instance. The library will send query for both SRV and ADDR records internally. 

The API now is this: 
```
    pub fn verify(&self, instance_fullname: String, timeout: Duration) -> Result<()> 
```
