### PR TITLE
perf: avoid cloning in filtering ptr

### DIFF
--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -378,6 +378,7 @@ impl DnsCache {
             .get(ty_domain)
             .into_iter()
             .flatten()
+            .filter(|record| !record.get_record().is_expired(now))
             .filter_map(|record| {
                 record
                     .any()
@@ -417,6 +418,7 @@ impl DnsCache {
             .get(ty_domain)
             .into_iter()
             .flatten()
+            .filter(|record| !record.get_record().is_expired(now))
             .filter_map(|record| {
                 record
                     .any()

--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -396,8 +396,8 @@ impl DnsCache {
         (refresh_due, new_timers)
     }
     
-    fn find_instance_names<'a>(from: &'a HashMap<String, Vec<DnsRecordBox>>, name: &str, now: u64) -> Vec<&'a String> {
-        from.get(name)
+    fn find_instance_names<'a>(from: &'a HashMap<String, Vec<DnsRecordBox>>, ty_domain: &str, now: u64) -> Vec<&'a String> {
+        from.get(ty_domain)
             .into_iter()
             .flatten()
             .filter(|record| !record.get_record().is_expired(now))

--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -395,8 +395,12 @@ impl DnsCache {
 
         (refresh_due, new_timers)
     }
-    
-    fn find_instance_names<'a>(from: &'a HashMap<String, Vec<DnsRecordBox>>, ty_domain: &str, now: u64) -> Vec<&'a String> {
+
+    fn find_instance_names<'a>(
+        from: &'a HashMap<String, Vec<DnsRecordBox>>,
+        ty_domain: &str,
+        now: u64,
+    ) -> Vec<&'a String> {
         from.get(ty_domain)
             .into_iter()
             .flatten()

--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -373,7 +373,7 @@ impl DnsCache {
     pub(crate) fn refresh_due_srv(&mut self, ty_domain: &str) -> (HashSet<String>, HashSet<u64>) {
         let now = current_time_millis();
 
-        let instances = Self::find_instance_names(&mut self.ptr, ty_domain, now);
+        let instances = Self::find_instance_names(&self.ptr, ty_domain, now);
 
         // Check SRV records.
         let mut refresh_due = HashSet::new();

--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -400,7 +400,7 @@ impl DnsCache {
         from.get(name)
             .into_iter()
             .flatten()
-            .filter(|record| record.get_record().is_expired(now))
+            .filter(|record| !record.get_record().is_expired(now))
             .flat_map(|record| record.any().downcast_ref::<DnsPointer>())
             .map(|ptr| &ptr.alias)
             .collect()


### PR DESCRIPTION
~~Extracts the filtering of instance names of a `ty_domain` in a function as it was used in 2 places exactly the same~~, the replaced code does not clone all the names, instead returns references to it (this is a perf improvement, as now they are being cloned only on demand (in checking the SRV records)) and I find this to be more concise and declarative, thoughts?

Tests pass on MacOS 14.5.