### PR TITLE
refactoring: define an enum for DNS resource record types

### DIFF
--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -6,8 +6,7 @@
 use crate::log::debug;
 use crate::{
     dns_parser::{
-        current_time_millis, split_sub_domain, DnsAddress, DnsPointer, DnsRecordBox, DnsSrv,
-        RR_TYPE_A, RR_TYPE_AAAA, RR_TYPE_NSEC, RR_TYPE_PTR, RR_TYPE_SRV, RR_TYPE_TXT,
+        current_time_millis, split_sub_domain, DnsAddress, DnsPointer, DnsRecordBox, DnsSrv, RRType,
     },
     service_info::valid_two_addrs_on_intf,
 };
@@ -121,7 +120,7 @@ impl DnsCache {
             return Vec::new();
         };
 
-        let mut query_vec = vec![(instance.to_string(), RR_TYPE_SRV)];
+        let mut query_vec = vec![(instance.to_string(), RRType::SRV as u16)];
 
         for srv in srv_vec {
             if let Some(new_expire) = expire_at {
@@ -133,8 +132,8 @@ impl DnsCache {
             };
 
             // Will verify addresses for the hostname.
-            query_vec.push((srv_record.host.clone(), RR_TYPE_A));
-            query_vec.push((srv_record.host.clone(), RR_TYPE_AAAA));
+            query_vec.push((srv_record.host.clone(), RRType::A as u16));
+            query_vec.push((srv_record.host.clone(), RRType::AAAA as u16));
 
             if let Some(new_expire) = expire_at {
                 if let Some(addrs) = self.addr.get_mut(&srv_record.host) {
@@ -161,10 +160,11 @@ impl DnsCache {
         timers: &mut Vec<u64>,
     ) -> Option<(&DnsRecordBox, bool)> {
         let entry_name = incoming.get_name().to_string();
+        let incoming_rrtype = RRType::from_u16(incoming.get_type())?;
 
         // If it is PTR with subtype, store a mapping from the instance fullname
         // to the subtype in this cache.
-        if incoming.get_type() == RR_TYPE_PTR {
+        if incoming_rrtype == RRType::PTR {
             let (_, subtype_opt) = split_sub_domain(&entry_name);
             if let Some(subtype) = subtype_opt {
                 if let Some(ptr) = incoming.any().downcast_ref::<DnsPointer>() {
@@ -176,12 +176,12 @@ impl DnsCache {
         }
 
         // get the existing records for the type.
-        let record_vec = match incoming.get_type() {
-            RR_TYPE_PTR => self.ptr.entry(entry_name).or_default(),
-            RR_TYPE_SRV => self.srv.entry(entry_name).or_default(),
-            RR_TYPE_TXT => self.txt.entry(entry_name).or_default(),
-            RR_TYPE_A | RR_TYPE_AAAA => self.addr.entry(entry_name).or_default(),
-            RR_TYPE_NSEC => self.nsec.entry(entry_name).or_default(),
+        let record_vec = match incoming_rrtype {
+            RRType::PTR => self.ptr.entry(entry_name).or_default(),
+            RRType::SRV => self.srv.entry(entry_name).or_default(),
+            RRType::TXT => self.txt.entry(entry_name).or_default(),
+            RRType::A | RRType::AAAA => self.addr.entry(entry_name).or_default(),
+            RRType::NSEC => self.nsec.entry(entry_name).or_default(),
             _ => return None,
         };
 
@@ -208,7 +208,7 @@ impl DnsCache {
                     should_flush = true;
 
                     // additional checks for address records.
-                    if rtype == RR_TYPE_A || rtype == RR_TYPE_AAAA {
+                    if rtype == RRType::A as u16 || rtype == RRType::AAAA as u16 {
                         if let Some(addr) = r.any().downcast_ref::<DnsAddress>() {
                             if let Some(addr_b) = incoming.any().downcast_ref::<DnsAddress>() {
                                 should_flush =
@@ -254,11 +254,11 @@ impl DnsCache {
     pub(crate) fn remove(&mut self, record: &DnsRecordBox) -> bool {
         let mut found = false;
         let record_name = record.get_name();
-        let record_vec = match record.get_type() {
-            RR_TYPE_PTR => self.ptr.get_mut(record_name),
-            RR_TYPE_SRV => self.srv.get_mut(record_name),
-            RR_TYPE_TXT => self.txt.get_mut(record_name),
-            RR_TYPE_A | RR_TYPE_AAAA => self.addr.get_mut(record_name),
+        let record_vec = match RRType::from_u16(record.get_type()) {
+            Some(RRType::PTR) => self.ptr.get_mut(record_name),
+            Some(RRType::SRV) => self.srv.get_mut(record_name),
+            Some(RRType::TXT) => self.txt.get_mut(record_name),
+            Some(RRType::A) | Some(RRType::AAAA) => self.addr.get_mut(record_name),
             _ => return found,
         };
         if let Some(record_vec) = record_vec {
@@ -500,11 +500,15 @@ impl DnsCache {
         qtype: u16,
         now: u64,
     ) -> Vec<&'a DnsRecordBox> {
-        let records_opt = match qtype {
-            RR_TYPE_PTR => self.get_ptr(name),
-            RR_TYPE_SRV => self.get_srv(name),
-            RR_TYPE_A | RR_TYPE_AAAA => self.get_addr(name),
-            RR_TYPE_TXT => self.get_txt(name),
+        let Some(rr_type) = RRType::from_u16(qtype) else {
+            return Vec::new();
+        };
+
+        let records_opt = match rr_type {
+            RRType::PTR => self.get_ptr(name),
+            RRType::SRV => self.get_srv(name),
+            RRType::A | RRType::AAAA => self.get_addr(name),
+            RRType::TXT => self.get_txt(name),
             _ => None,
         };
 

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -25,6 +25,7 @@ use std::{
 /// DNS resource record types
 /// See [RFC 1035 section 3.2.2](https://datatracker.ietf.org/doc/html/rfc1035#section-3.2.2)
 #[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
+#[non_exhaustive]
 #[repr(u16)]
 pub enum RRType {
     /// DNS record type for IPv4 address

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,10 +151,7 @@ mod error;
 mod service_daemon;
 mod service_info;
 
-pub use dns_parser::{
-    RR_TYPE_A, RR_TYPE_AAAA, RR_TYPE_ANY, RR_TYPE_CNAME, RR_TYPE_HINFO, RR_TYPE_NSEC, RR_TYPE_PTR,
-    RR_TYPE_SRV, RR_TYPE_TXT,
-};
+pub use dns_parser::RRType;
 pub use error::{Error, Result};
 pub use service_daemon::{
     DaemonEvent, DaemonStatus, DnsNameChange, HostnameResolutionEvent, IfKind, Metrics,

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "logging")]
 use crate::log::{error, info};
 use crate::{
-    dns_parser::{rr_type_name, split_sub_domain, DnsRecordBox, DnsRecordExt, DnsSrv, RR_TYPE_SRV},
+    dns_parser::{rr_type_name, split_sub_domain, DnsRecordBox, DnsRecordExt, DnsSrv, RRType},
     Error, Result,
 };
 use if_addrs::{IfAddr, Interface};
@@ -993,7 +993,7 @@ impl DnsRegistry {
 
         for (_name, probe) in self.probing.iter_mut() {
             probe.records.retain(|record| {
-                if record.get_type() == RR_TYPE_SRV {
+                if record.get_type() == RRType::SRV as u16 {
                     if let Some(srv) = record.any().downcast_ref::<DnsSrv>() {
                         if srv.host == original {
                             let mut new_record = srv.clone();
@@ -1009,7 +1009,7 @@ impl DnsRegistry {
 
         for (_name, records) in self.active.iter_mut() {
             records.retain(|record| {
-                if record.get_type() == RR_TYPE_SRV {
+                if record.get_type() == RRType::SRV as u16 {
                     if let Some(srv) = record.any().downcast_ref::<DnsSrv>() {
                         if srv.host == original {
                             let mut new_record = srv.clone();

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "logging")]
 use crate::log::{error, info};
 use crate::{
-    dns_parser::{rr_type_name, split_sub_domain, DnsRecordBox, DnsRecordExt, DnsSrv, RRType},
+    dns_parser::{split_sub_domain, DnsRecordBox, DnsRecordExt, DnsSrv, RRType},
     Error, Result,
 };
 use if_addrs::{IfAddr, Interface};
@@ -938,7 +938,7 @@ impl DnsRegistry {
                 if answer.matches(record.as_ref()) {
                     info!(
                         "found active record {} {}",
-                        rr_type_name(answer.get_type()),
+                        answer.get_type(),
                         answer.get_name(),
                     );
                     return true;
@@ -960,7 +960,7 @@ impl DnsRegistry {
             if answer.matches(record.as_ref()) {
                 info!(
                     "found existing record {} in probe of '{}'",
-                    rr_type_name(answer.get_type()),
+                    answer.get_type(),
                     answer.get_name(),
                 );
                 probe.waiting_services.insert(service_name.to_string());
@@ -970,7 +970,7 @@ impl DnsRegistry {
 
         info!(
             "insert record {} into probe of {}",
-            rr_type_name(answer.get_type()),
+            answer.get_type(),
             answer.get_name(),
         );
         probe.insert_record(answer.clone_box());
@@ -993,7 +993,7 @@ impl DnsRegistry {
 
         for (_name, probe) in self.probing.iter_mut() {
             probe.records.retain(|record| {
-                if record.get_type() == RRType::SRV as u16 {
+                if record.get_type() == RRType::SRV {
                     if let Some(srv) = record.any().downcast_ref::<DnsSrv>() {
                         if srv.host == original {
                             let mut new_record = srv.clone();
@@ -1009,7 +1009,7 @@ impl DnsRegistry {
 
         for (_name, records) in self.active.iter_mut() {
             records.retain(|record| {
-                if record.get_type() == RRType::SRV as u16 {
+                if record.get_type() == RRType::SRV {
                     if let Some(srv) = record.any().downcast_ref::<DnsSrv>() {
                         if srv.host == original {
                             let mut new_record = srv.clone();
@@ -1041,7 +1041,7 @@ impl DnsRegistry {
 
             info!(
                 "insert record {} with new hostname {new_name} into probe for: {}",
-                rr_type_name(record.get_type()),
+                record.get_type(),
                 record.get_name()
             );
             probe.insert_record(Box::new(record));


### PR DESCRIPTION
Use the new type `RRType` instead of `u16` in most cases.