### PR TITLE
new API to set multicast loop v4 for ServiceDaemon

### DIFF
--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -401,9 +401,20 @@ impl ServiceDaemon {
         )))
     }
 
-    /// Enable or disable the loopback for locally sent multicast packets.
+    /// Enable or disable the loopback for locally sent multicast packets in IPv4.
     ///
-    /// When disabled, a local querier will not receive announcements from a local responder.
+    /// When disabled, a querier will not receive announcements from a responder on the same host.
+    ///
+    /// Reference: https://learn.microsoft.com/en-us/windows/win32/winsock/ip-multicast-2
+    ///
+    /// "The Winsock version of the IP_MULTICAST_LOOP option is semantically different than
+    /// the UNIX version of the IP_MULTICAST_LOOP option:
+    ///
+    /// In Winsock, the IP_MULTICAST_LOOP option applies only to the receive path.
+    /// In the UNIX version, the IP_MULTICAST_LOOP option applies to the send path."
+    ///
+    /// Which means, in order NOT to receive localhost announcements, you want to call
+    /// this API on the querier side on Windows, but on the responder side on Unix.
     pub fn set_multicast_loop_v4(&self, on: bool) -> Result<()> {
         self.send_cmd(Command::SetOption(DaemonOption::MulticastLoopV4(on)))
     }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -403,7 +403,8 @@ impl ServiceDaemon {
 
     /// Enable or disable the loopback for locally sent multicast packets in IPv4.
     ///
-    /// When disabled, a querier will not receive announcements from a responder on the same host.
+    /// By default, multicast loop is enabled for IPv4. When disabled, a querier will not
+    /// receive announcements from a responder on the same host.
     ///
     /// Reference: https://learn.microsoft.com/en-us/windows/win32/winsock/ip-multicast-2
     ///
@@ -421,7 +422,8 @@ impl ServiceDaemon {
 
     /// Enable or disable the loopback for locally sent multicast packets in IPv6.
     ///
-    /// When disabled, a querier will not receive announcements from a responder on the same host.
+    /// By default, multicast loop is enabled for IPv6. When disabled, a querier will not
+    /// receive announcements from a responder on the same host.
     ///
     /// Reference: https://learn.microsoft.com/en-us/windows/win32/winsock/ip-multicast-2
     ///

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1854,6 +1854,83 @@ fn test_verify_srv() {
     assert!(service_removal);
 }
 
+#[test]
+fn test_multicast_loop_v4() {
+    let ty_domain = "_loop_v4._udp.local.";
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap();
+    let instance_name = now.as_micros().to_string(); // Create a unique name.
+    let host_name = "loop_v4_host.local.";
+    let port = 5200;
+
+    // Register the first service.
+    let server = ServiceDaemon::new().expect("failed to start server");
+    server.set_multicast_loop_v4(false).unwrap();
+
+    // Get a single IPv4 address
+    let ip_addr1 = my_ip_interfaces()
+        .iter()
+        .find(|iface| iface.ip().is_ipv4())
+        .map(|iface| iface.ip())
+        .unwrap();
+
+    // Publish the service on server
+    let service1 = ServiceInfo::new(ty_domain, &instance_name, host_name, &ip_addr1, port, None)
+        .expect("valid service info");
+    server
+        .register(service1)
+        .expect("Failed to register service1");
+
+    // wait for the service announced.
+    sleep(Duration::from_secs(1));
+
+    // start a client i.e. querier.
+    let mut resolved = false;
+    let client = ServiceDaemon::new().expect("failed to create mdns client");
+    let receiver = client.browse(ty_domain).unwrap();
+
+    let timeout = Duration::from_secs(2);
+    while let Ok(event) = receiver.recv_timeout(timeout) {
+        match event {
+            ServiceEvent::ServiceResolved(info) => {
+                println!(
+                    "Resolved a service: {} host {} IP {:?}",
+                    info.get_fullname(),
+                    info.get_hostname(),
+                    info.get_addresses_v4()
+                );
+                resolved = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    assert_eq!(resolved, false);
+
+    // enable loopback and try again.
+    server.set_multicast_loop_v4(true).unwrap();
+
+    while let Ok(event) = receiver.recv_timeout(timeout) {
+        match event {
+            ServiceEvent::ServiceResolved(info) => {
+                println!(
+                    "Resolved a service: {} host {} IP {:?}",
+                    info.get_fullname(),
+                    info.get_hostname(),
+                    info.get_addresses_v4()
+                );
+                resolved = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    assert!(resolved);
+}
+
 /// A helper function to include a timestamp for println.
 fn timed_println(msg: String) {
     let now = SystemTime::now();

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1888,6 +1888,10 @@ fn test_multicast_loop_v4() {
     // start a client i.e. querier.
     let mut resolved = false;
     let client = ServiceDaemon::new().expect("failed to create mdns client");
+
+    // For Windows, IP_MULTICAST_LOOP option works only on the receive path.
+    client.set_multicast_loop_v4(false).unwrap();
+
     let receiver = client.browse(ty_domain).unwrap();
 
     let timeout = Duration::from_secs(2);
@@ -1911,6 +1915,8 @@ fn test_multicast_loop_v4() {
 
     // enable loopback and try again.
     server.set_multicast_loop_v4(true).unwrap();
+    client.set_multicast_loop_v4(true).unwrap();
+    let receiver = client.browse(ty_domain).unwrap();
 
     while let Ok(event) = receiver.recv_timeout(timeout) {
         match event {

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1937,6 +1937,90 @@ fn test_multicast_loop_v4() {
     assert!(resolved);
 }
 
+#[test]
+fn test_multicast_loop_v6() {
+    let ty_domain = "_loop_v6._udp.local.";
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap();
+    let instance_name = now.as_micros().to_string(); // Create a unique name.
+    let host_name = "loop_v6_host.local.";
+    let port = 5200;
+
+    // Register the first service.
+    let server = ServiceDaemon::new().expect("failed to start server");
+    server.set_multicast_loop_v6(false).unwrap();
+
+    // Get a single IPv4 address
+    let ip_addr1 = my_ip_interfaces()
+        .iter()
+        .find(|iface| iface.ip().is_ipv6())
+        .map(|iface| iface.ip())
+        .unwrap();
+
+    // Publish the service on server
+    let service1 = ServiceInfo::new(ty_domain, &instance_name, host_name, &ip_addr1, port, None)
+        .expect("valid service info");
+    server
+        .register(service1)
+        .expect("Failed to register service1");
+
+    // wait for the service announced.
+    sleep(Duration::from_secs(1));
+
+    // start a client i.e. querier.
+    let mut resolved = false;
+    let client = ServiceDaemon::new().expect("failed to create mdns client");
+
+    // For Windows, IP_MULTICAST_LOOP option works only on the receive path.
+    client.set_multicast_loop_v6(false).unwrap();
+
+    let receiver = client.browse(ty_domain).unwrap();
+
+    let timeout = Duration::from_secs(2);
+    while let Ok(event) = receiver.recv_timeout(timeout) {
+        match event {
+            ServiceEvent::ServiceResolved(info) => {
+                println!(
+                    "Resolved a service: {} host {} IP {:?}",
+                    info.get_fullname(),
+                    info.get_hostname(),
+                    info.get_addresses()
+                );
+                resolved = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    assert_eq!(resolved, false);
+
+    // enable loopback and try again.
+    server.set_multicast_loop_v6(true).unwrap();
+    client.set_multicast_loop_v6(true).unwrap();
+
+    let receiver = client.browse(ty_domain).unwrap();
+
+    while let Ok(event) = receiver.recv_timeout(timeout) {
+        match event {
+            ServiceEvent::ServiceResolved(info) => {
+                println!(
+                    "Resolved a service: {} host {} IP {:?}",
+                    info.get_fullname(),
+                    info.get_hostname(),
+                    info.get_addresses()
+                );
+                resolved = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    assert!(resolved);
+}
+
 /// A helper function to include a timestamp for println.
 fn timed_println(msg: String) {
     let now = SystemTime::now();


### PR DESCRIPTION
This patch is trying to solve issue #278 . I'm curious if this new API can support what was asked: 

```rust
/// Enable or disable the loopback for locally sent multicast packets.
///
/// When disabled, a local querier will not receive announcements from a local responder.
pub fn set_multicast_loop_v4(&self, on: bool) -> Result<()>
```


