### PR TITLE
test: fix a flaky test

### DIFF
--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1546,9 +1546,12 @@ fn test_name_conflict_resolution() {
                 service_names.insert(info.get_fullname().to_string());
 
                 // Find and verify name conflict resolution.
-
                 if info.get_fullname().contains("(2)") {
                     assert_eq!(info.get_hostname(), "conflict_host-2.local.");
+                }
+
+                // Stop the wait if both are resolved.
+                if service_names.len() == 2 {
                     break;
                 }
             }


### PR DESCRIPTION
For example, this test [run failed](https://github.com/keepsimple1/mdns-sd/actions/runs/12270151076/job/34234918165).
