### PR TITLE
TxtProperties: new method to get a HashMap of properties

### DIFF
--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -501,12 +501,17 @@ impl TxtProperties {
     }
 
     /// Returns a map of properties, where the key is the property key.
-    pub fn get_property_map_str(&self) -> HashMap<String, String> {
-        let mut map = HashMap::new();
-        for prop in self.properties.iter() {
-            map.insert(prop.key.clone(), prop.val_str().to_string());
-        }
-        map
+    pub fn into_property_map_str(self) -> HashMap<String, String> {
+        self.properties
+            .into_iter()
+            .map(|p| {
+                (
+                    p.key,
+                    p.val
+                        .map_or_else(String::new, |v| String::from_utf8(v).unwrap_or_default()),
+                )
+            })
+            .collect()
     }
 }
 

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -499,6 +499,15 @@ impl TxtProperties {
     pub fn get_property_val_str(&self, key: &str) -> Option<&str> {
         self.get(key).map(|x| x.val_str())
     }
+
+    /// Returns a map of properties, where the key is the property key.
+    pub fn get_property_map_str(&self) -> HashMap<String, String> {
+        let mut map = HashMap::new();
+        for prop in self.properties.iter() {
+            map.insert(prop.key.clone(), prop.val_str().to_string());
+        }
+        map
+    }
 }
 
 impl fmt::Display for TxtProperties {

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -500,13 +500,14 @@ impl TxtProperties {
         self.get(key).map(|x| x.val_str())
     }
 
-    /// Returns properties as a hashmap, where the keys are the properties keys.
+    /// Consumes properties and returns a hashmap, where the keys are the properties keys.
+    ///
+    /// If a property value is empty, return an empty string (because RFC 6763 allows empty values).
+    /// If a property value is non-empty but not valid UTF-8, skip the property and log a message.
     pub fn into_property_map_str(self) -> HashMap<String, String> {
         self.properties
             .into_iter()
             .filter_map(|property| {
-                // If the value is empty, return an empty string (because RFC 6763 allows empty values).
-                // If the value is non-empty but not valid UTF-8, skip the property and log a message.
                 let val_string = property.val.map_or(Some(String::new()), |val| {
                     String::from_utf8(val)
                         .map_err(|e| {
@@ -697,6 +698,12 @@ where
             }
         }
         TxtProperties { properties }
+    }
+}
+
+impl IntoTxtProperties for Vec<TxtProperty> {
+    fn into_txt_properties(self) -> TxtProperties {
+        TxtProperties { properties: self }
     }
 }
 

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -504,12 +504,12 @@ impl TxtProperties {
     pub fn into_property_map_str(self) -> HashMap<String, String> {
         self.properties
             .into_iter()
-            .map(|p| {
-                (
-                    p.key,
-                    p.val
-                        .map_or_else(String::new, |v| String::from_utf8(v).unwrap_or_default()),
-                )
+            .filter_map(|p| {
+                // Skip the property if the value is non-empty and not valid UTF-8.
+                let value = p
+                    .val
+                    .map_or(Some(String::new()), |v| String::from_utf8(v).ok())?;
+                Some((p.key, value))
             })
             .collect()
     }


### PR DESCRIPTION
This is to follow up on issue #300 . Added a new method that consumes `TxtProperties` and returns a simple HashMap.