### PR TITLE
Including Loopback Addresses Properly and Proposing a Feature Flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ description = "mDNS Service Discovery library with no async runtime dependency"
 [features]
 async = ["flume/async"]
 logging = ["log"]
+loopback = []
 default = ["async", "logging"]
 
 [dependencies]

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -3121,6 +3121,18 @@ fn call_hostname_resolution_listener(
 }
 
 /// Returns valid network interfaces in the host system.
+/// Loopback interfaces are excluded.
+#[cfg(not(feature = "loopback"))]
+fn my_ip_interfaces() -> Vec<Interface> {
+    if_addrs::get_if_addrs()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|i| !i.is_loopback())
+        .collect()
+}
+
+/// Returns valid network interfaces in the host system.
+#[cfg(feature = "loopback")]
 fn my_ip_interfaces() -> Vec<Interface> {
     if_addrs::get_if_addrs()
         .unwrap_or_default()

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -3121,12 +3121,10 @@ fn call_hostname_resolution_listener(
 }
 
 /// Returns valid network interfaces in the host system.
-/// Loopback interfaces are excluded.
 fn my_ip_interfaces() -> Vec<Interface> {
     if_addrs::get_if_addrs()
         .unwrap_or_default()
         .into_iter()
-        .filter(|i| !i.is_loopback())
         .collect()
 }
 

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -291,6 +291,8 @@ impl ServiceInfo {
     pub(crate) fn get_addrs_on_intf(&self, intf: &Interface) -> Vec<IpAddr> {
         self.addresses
             .iter()
+            // Allow loopback addresses to support registering services on loopback interfaces,
+            // which is required by some use cases (e.g., OSCQuery) that publish via mDNS.
             .filter(|a| (a.is_loopback() || valid_ip_on_intf(a, intf)))
             .copied()
             .collect()

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -291,9 +291,7 @@ impl ServiceInfo {
     pub(crate) fn get_addrs_on_intf(&self, intf: &Interface) -> Vec<IpAddr> {
         self.addresses
             .iter()
-            // Allow loopback addresses to support registering services on loopback interfaces,
-            // which is required by some use cases (e.g., OSCQuery) that publish via mDNS.
-            .filter(|a| (a.is_loopback() || valid_ip_on_intf(a, intf)))
+            .filter(|a| valid_ip_on_intf(a, intf))
             .copied()
             .collect()
     }

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -291,7 +291,7 @@ impl ServiceInfo {
     pub(crate) fn get_addrs_on_intf(&self, intf: &Interface) -> Vec<IpAddr> {
         self.addresses
             .iter()
-            .filter(|a| valid_ip_on_intf(a, intf))
+            .filter(|a| (a.is_loopback() || valid_ip_on_intf(a, intf)))
             .copied()
             .collect()
     }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -779,8 +779,15 @@ fn service_with_loopback_addr() {
     let loopback_ip: IpAddr = "127.0.0.1".parse().unwrap();
     let host_name = "localhost.local.";
     let port = 5201;
-    let my_service = ServiceInfo::new(ty_domain, &instance_name, host_name, loopback_ip, port, None)
-        .expect("valid service info");
+    let my_service = ServiceInfo::new(
+        ty_domain,
+        &instance_name,
+        host_name,
+        loopback_ip,
+        port,
+        None,
+    )
+    .expect("valid service info");
     d.register(my_service)
         .expect("Failed to register our service");
 
@@ -817,7 +824,10 @@ fn service_with_loopback_addr() {
     d.shutdown().unwrap();
 
     // Assert that the resolved service includes a loopback address.
-    assert!(found_loopback, "The service should include a loopback address");
+    assert!(
+        found_loopback,
+        "The service should include a loopback address"
+    );
 }
 
 #[test]

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -825,7 +825,11 @@ fn service_with_loopback_addr() {
 
     // Assert that the resolved service includes a loopback address.
     assert!(
-        if cfg!(feature = "loopback") { found_loopback } else { !found_loopback },
+        if cfg!(feature = "loopback") {
+            found_loopback
+        } else {
+            !found_loopback
+        },
         "The service should include a loopback address"
     );
 }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -764,6 +764,63 @@ fn service_with_invalid_addr_v6() {
 }
 
 #[test]
+fn service_with_loopback_addr() {
+    // Create a daemon
+    let d = ServiceDaemon::new().expect("Failed to create daemon");
+
+    // Define a unique service type and instance name.
+    let ty_domain = "_test-loopback._tcp.local.";
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap();
+    let instance_name = now.as_micros().to_string();
+
+    // Use a loopback address (127.0.0.1) for the service.
+    let loopback_ip: IpAddr = "127.0.0.1".parse().unwrap();
+    let host_name = "localhost.local.";
+    let port = 5201;
+    let my_service = ServiceInfo::new(ty_domain, &instance_name, host_name, loopback_ip, port, None)
+        .expect("valid service info");
+    d.register(my_service)
+        .expect("Failed to register our service");
+
+    // Browse for the service.
+    let browse_chan = d.browse(ty_domain).unwrap();
+    let timeout = Duration::from_secs(2);
+    let mut found_loopback = false;
+    loop {
+        match browse_chan.recv_timeout(timeout) {
+            Ok(event) => match event {
+                ServiceEvent::ServiceResolved(info) => {
+                    println!(
+                        "Resolved service {} with addresses: {:?}",
+                        info.get_fullname(),
+                        info.get_addresses()
+                    );
+                    // Check that at least one of the addresses is a loopback address.
+                    if info.get_addresses().iter().any(|ip| ip.is_loopback()) {
+                        found_loopback = true;
+                    }
+                    break;
+                }
+                e => {
+                    println!("Received event {:?}", e);
+                }
+            },
+            Err(e) => {
+                println!("browse error: {}", e);
+                break;
+            }
+        }
+    }
+
+    d.shutdown().unwrap();
+
+    // Assert that the resolved service includes a loopback address.
+    assert!(found_loopback, "The service should include a loopback address");
+}
+
+#[test]
 fn subtype() {
     // Create a daemon
     let d = ServiceDaemon::new().expect("Failed to create daemon");

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -825,7 +825,7 @@ fn service_with_loopback_addr() {
 
     // Assert that the resolved service includes a loopback address.
     assert!(
-        found_loopback,
+        if cfg!(feature = "loopback") { found_loopback } else { !found_loopback },
         "The service should include a loopback address"
     );
 }


### PR DESCRIPTION
Hello,

This pull request addresses an issue with how we handle network interface enumeration. In a previous PR (#306 ), we modified the behavior to allow returning loopback addresses. However, because announcements are not sent over the loopback address space, other services have had difficulty discovering published services.

To resolve the discovery issue, this change removes the exclusion filter so that loopback addresses are included. However, note that announcing on loopback interfaces may introduce potential performance issues, since announcements would then always be made on these interfaces.

Proposal:
I suggest that we consider reverting the previous PR (#306) and apply this change behind a feature flag or configuration option. This would allow users to opt in or out of loopback announcements based on their performance needs and use case.

Please review the changes and share any feedback or concerns regarding the proposed feature flag approach. I appreciate your time and look forward to your suggestions.

Thank you.