### PR TITLE
refactoring: make e_fmt! available within the crate

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -7,7 +7,7 @@
 #[cfg(feature = "logging")]
 use crate::log::trace;
 
-use crate::error::e_fmt;
+use crate::error::{e_fmt, Error, Result};
 
 use std::{
     any::Any,
@@ -2190,32 +2190,3 @@ const fn get_expiration_time(created: u64, ttl: u32, percent: u32) -> u64 {
     // ttl * 1000 * (percent / 100) => ttl * percent * 10
     created + (ttl * percent * 10) as u64
 }
-
-/// A basic error type from this library.
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum Error {
-    /// Like a classic EAGAIN. The receiver should retry.
-    Again,
-
-    /// A generic error message.
-    Msg(String),
-
-    /// Error during parsing of ip address
-    ParseIpAddr(String),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Msg(s) => write!(f, "{}", s),
-            Self::ParseIpAddr(s) => write!(f, "parsing of ip addr failed, reason: {}", s),
-            Self::Again => write!(f, "try again"),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
-
-/// One and only `Result` type from this library crate.
-pub type Result<T> = core::result::Result<T, Error>;

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -7,6 +7,8 @@
 #[cfg(feature = "logging")]
 use crate::log::trace;
 
+use crate::error::e_fmt;
+
 use std::{
     any::Any,
     cmp,
@@ -1741,10 +1743,10 @@ impl DnsIncoming {
 
     fn read_header(&mut self) -> Result<()> {
         if self.data.len() < MSG_HEADER_LEN {
-            return Err(Error::Msg(format!(
+            return Err(e_fmt!(
                 "DNS incoming: header is too short: {} bytes",
                 self.data.len()
-            )));
+            ));
         }
 
         let data = &self.data[0..];

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,3 +28,12 @@ impl std::error::Error for Error {}
 
 /// One and only `Result` type from this library crate.
 pub type Result<T> = core::result::Result<T, Error>;
+
+/// A simple macro to report all kinds of errors.
+macro_rules! e_fmt {
+    ($($arg:tt)+) => {
+        Error::Msg(format!($($arg)+))
+    };
+  }
+
+pub(crate) use e_fmt;

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -37,7 +37,7 @@ use crate::{
         DnsRecordBox, DnsRecordExt, DnsSrv, DnsTxt, RRType, CLASS_CACHE_FLUSH, CLASS_IN, FLAGS_AA,
         FLAGS_QR_QUERY, FLAGS_QR_RESPONSE, MAX_MSG_ABSOLUTE,
     },
-    error::{Error, Result},
+    error::{e_fmt, Error, Result},
     service_info::{
         split_sub_domain, valid_ip_on_intf, DnsRegistry, Probe, ServiceInfo, ServiceStatus,
     },
@@ -56,13 +56,6 @@ use std::{
     time::Duration,
     vec,
 };
-
-/// A simple macro to report all kinds of errors.
-macro_rules! e_fmt {
-  ($($arg:tt)+) => {
-      Error::Msg(format!($($arg)+))
-  };
-}
 
 /// The default max length of the service name without domain, not including the
 /// leading underscore (`_`). It is set to 15 per


### PR DESCRIPTION
- `e_fmt!` macro belongs to `error.rs` and so that all modules in this crate can use it.
- also removed duplicated code (leftover from #284) 