### PR TITLE
Detect IP changes: reduce the interval

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,8 +155,8 @@ pub use dns_parser::RRType;
 pub use error::{Error, Result};
 pub use service_daemon::{
     DaemonEvent, DaemonStatus, DnsNameChange, HostnameResolutionEvent, IfKind, Metrics,
-    ServiceDaemon, ServiceEvent, UnregisterStatus, SERVICE_NAME_LEN_MAX_DEFAULT,
-    VERIFY_TIMEOUT_DEFAULT,
+    ServiceDaemon, ServiceEvent, UnregisterStatus, IP_CHECK_INTERVAL_IN_SECS_DEFAULT,
+    SERVICE_NAME_LEN_MAX_DEFAULT, VERIFY_TIMEOUT_DEFAULT,
 };
 pub use service_info::{
     AsIpAddrs, IntoTxtProperties, ResolvedService, ServiceInfo, TxtProperties, TxtProperty,

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -504,7 +504,7 @@ impl ServiceDaemon {
         }
 
         // Setup timer for IP checks.
-        const IP_CHECK_INTERVAL_MILLIS: u64 = 30_000;
+        const IP_CHECK_INTERVAL_MILLIS: u64 = 3_000;
         let mut next_ip_check = current_time_millis() + IP_CHECK_INTERVAL_MILLIS;
         zc.add_timer(next_ip_check);
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -375,9 +375,9 @@ impl ServiceDaemon {
 
     /// Change the interval for checking IP changes automatically.
     ///
-    /// Setting `interval` to 0 disables the IP check.
+    /// Setting the interval to 0 disables the IP check.
     ///
-    /// The default interval is 5 seconds, see [`IP_CHECK_INTERVAL_IN_SECS_DEFAULT`].
+    /// See [`IP_CHECK_INTERVAL_IN_SECS_DEFAULT`] for the default interval.
     pub fn set_ip_check_interval(&self, interval_in_secs: u32) -> Result<()> {
         let interval_in_millis = interval_in_secs as u64 * 1000;
         self.send_cmd(Command::SetOption(DaemonOption::IpCheckInterval(

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -377,7 +377,7 @@ impl ServiceDaemon {
     ///
     /// Setting `interval` to 0 disables the IP check.
     ///
-    /// The default interval is 5 seconds, see [`IP_CHECK_INTERVAL_DEFAULT`].
+    /// The default interval is 5 seconds, see [`IP_CHECK_INTERVAL_IN_SECS_DEFAULT`].
     pub fn set_ip_check_interval(&self, interval_in_secs: u32) -> Result<()> {
         let interval_in_millis = interval_in_secs as u64 * 1000;
         self.send_cmd(Command::SetOption(DaemonOption::IpCheckInterval(


### PR DESCRIPTION
This patch is to fix issue #312 .

- A new method `set_ip_check_interval` is added to allow users adjust the interval detecting IP changes.
- The default interval is 5 seconds.
- Setting the interval to 0 will disable the detection.