### PR TITLE
fix: remove related addresses in the cache when disabling an interface

### DIFF
--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -174,6 +174,20 @@ impl DnsCache {
             }
         }
 
+        if incoming.get_type() == RRType::A || incoming.get_type() == RRType::AAAA {
+            if let Some(answer_addr) = incoming.any().downcast_ref::<DnsAddress>() {
+                if !valid_ip_on_intf(&answer_addr.address(), intf)
+                    && !answer_addr.address().is_loopback()
+                {
+                    debug!(
+                        "conflict handler: answer addr {:?} not in the subnet of {:?}",
+                        answer_addr, intf
+                    );
+                    return None;
+                }
+            }
+        }
+
         // get the existing records for the type.
         let record_vec = match incoming.get_type() {
             RRType::PTR => self.ptr.entry(entry_name).or_default(),

--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -538,7 +538,10 @@ impl DnsCache {
 
                 // Remove the record if it is on this interface.
                 if valid_ip_on_intf(&dns_addr.address(), disabled_intf) {
-                    debug!("removing ADDR on disabled intf: {:?} host {host}", dns_addr);
+                    debug!(
+                        "removing ADDR on disabled intf: {:?} host {host}",
+                        dns_addr.address()
+                    );
                     false
                 } else {
                     true

--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -174,14 +174,15 @@ impl DnsCache {
             }
         }
 
+        // Check if address is valid on the interface. When IP_MULTICAST_LOOP is enabled,
+        // a multicast packet would loopback to other interfaces of the same multicast group on Linux.
         if incoming.get_type() == RRType::A || incoming.get_type() == RRType::AAAA {
             if let Some(answer_addr) = incoming.any().downcast_ref::<DnsAddress>() {
-                if !valid_ip_on_intf(&answer_addr.address(), intf)
-                    && !answer_addr.address().is_loopback()
-                {
+                let addr = answer_addr.address();
+                if !valid_ip_on_intf(&addr, intf) && !addr.is_loopback() {
                     debug!(
-                        "conflict handler: answer addr {:?} not in the subnet of {:?}",
-                        answer_addr, intf
+                        "add_or_update: answer addr {addr} not in the subnet of {}",
+                        intf.ip()
                     );
                     return None;
                 }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1115,17 +1115,14 @@ impl Zeroconf {
             if intf_selections[idx] {
                 // Add the interface
                 if !self.intf_socks.contains_key(&intf) {
-                    debug!("apply_intf_selections: add {:?} idx {idx}", &intf.ip());
+                    debug!("apply_intf_selections: add {:?}", &intf.ip());
                     self.add_new_interface(intf);
                 }
             } else {
                 // Remove the interface
                 if let Some(mut sock) = self.intf_socks.remove(&intf) {
                     match self.poller.registry().deregister(&mut sock) {
-                        Ok(()) => debug!(
-                            "apply_intf_selections: deregister {:?} idx {idx}",
-                            &intf.ip()
-                        ),
+                        Ok(()) => debug!("apply_intf_selections: deregister {:?}", &intf.ip()),
                         Err(e) => debug!("apply_intf_selections: poller.delete {:?}: {}", &intf, e),
                     }
 
@@ -2000,7 +1997,6 @@ impl Zeroconf {
                     updated_instances.insert(update.name);
                 }
                 RRType::A | RRType::AAAA => {
-                    debug!("addr update: {} intf {}", update.name, intf.ip());
                     let instances = self.cache.get_instances_on_host(&update.name);
                     updated_instances.extend(instances);
                 }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1120,9 +1120,11 @@ impl Zeroconf {
             } else {
                 // Remove the interface
                 if let Some(mut sock) = self.intf_socks.remove(&intf) {
-                    if let Err(e) = self.poller.registry().deregister(&mut sock) {
-                        debug!("process_if_selections: poller.delete {:?}: {}", &intf, e);
+                    match self.poller.registry().deregister(&mut sock) {
+                        Ok(()) => debug!("apply_intf_selections: deregister {:?}", &intf.ip()),
+                        Err(e) => debug!("apply_intf_selections: poller.delete {:?}: {}", &intf, e),
                     }
+
                     // Remove from poll_ids
                     self.poll_ids.retain(|_, v| v != &intf);
 
@@ -1718,7 +1720,7 @@ impl Zeroconf {
                     if info.is_ready() {
                         resolved.insert(ptr.alias().to_string());
                         match sender.send(ServiceEvent::ServiceResolved(info)) {
-                            Ok(()) => trace!("sent service resolved: {}", ptr.alias()),
+                            Ok(()) => debug!("sent service resolved: {}", ptr.alias()),
                             Err(e) => debug!("failed to send service resolved: {}", e),
                         }
                     } else {

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1115,13 +1115,17 @@ impl Zeroconf {
             if intf_selections[idx] {
                 // Add the interface
                 if !self.intf_socks.contains_key(&intf) {
+                    debug!("apply_intf_selections: add {:?} idx {idx}", &intf.ip());
                     self.add_new_interface(intf);
                 }
             } else {
                 // Remove the interface
                 if let Some(mut sock) = self.intf_socks.remove(&intf) {
                     match self.poller.registry().deregister(&mut sock) {
-                        Ok(()) => debug!("apply_intf_selections: deregister {:?}", &intf.ip()),
+                        Ok(()) => debug!(
+                            "apply_intf_selections: deregister {:?} idx {idx}",
+                            &intf.ip()
+                        ),
                         Err(e) => debug!("apply_intf_selections: poller.delete {:?}: {}", &intf, e),
                     }
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -2000,6 +2000,7 @@ impl Zeroconf {
                     updated_instances.insert(update.name);
                 }
                 RRType::A | RRType::AAAA => {
+                    debug!("addr update instance: {}", update.name);
                     let instances = self.cache.get_instances_on_host(&update.name);
                     updated_instances.extend(instances);
                 }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -2149,6 +2149,7 @@ impl Zeroconf {
                                     ty_domain,
                                     ServiceEvent::ServiceResolved(info),
                                 );
+                                debug!("called queriers to resolve {}", dns_ptr.alias());
                             } else {
                                 if self.resolved.remove(dns_ptr.alias()) {
                                     removed_instances

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1125,6 +1125,9 @@ impl Zeroconf {
                     }
                     // Remove from poll_ids
                     self.poll_ids.retain(|_, v| v != &intf);
+
+                    // Remove cache records for this interface.
+                    self.cache.remove_addrs_on_disabled_intf(&intf);
                 }
             }
         }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -2000,7 +2000,7 @@ impl Zeroconf {
                     updated_instances.insert(update.name);
                 }
                 RRType::A | RRType::AAAA => {
-                    debug!("addr update instance: {}", update.name);
+                    debug!("addr update: {} intf {}", update.name, intf.ip());
                     let instances = self.cache.get_instances_on_host(&update.name);
                     updated_instances.extend(instances);
                 }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1710,7 +1710,7 @@ impl Zeroconf {
                         ty_domain.to_string(),
                         ptr.alias().to_string(),
                     )) {
-                        Ok(()) => trace!("send service found {}", ptr.alias()),
+                        Ok(()) => debug!("send service found {}", ptr.alias()),
                         Err(e) => {
                             debug!("failed to send service found: {}", e);
                             continue;
@@ -2143,13 +2143,13 @@ impl Zeroconf {
                             self.create_service_info_from_cache(ty_domain, dns_ptr.alias())
                         {
                             if info.is_ready() {
+                                debug!("call queriers to resolve {}", dns_ptr.alias());
                                 resolved.insert(dns_ptr.alias().to_string());
                                 call_service_listener(
                                     &self.service_queriers,
                                     ty_domain,
                                     ServiceEvent::ServiceResolved(info),
                                 );
-                                debug!("called queriers to resolve {}", dns_ptr.alias());
                             } else {
                                 if self.resolved.remove(dns_ptr.alias()) {
                                     removed_instances

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -808,7 +808,7 @@ fn decode_txt_unique(txt: &[u8]) -> Vec<TxtProperty> {
 }
 
 /// Returns true if `addr` is in the same network of `intf`.
-pub fn valid_ip_on_intf(addr: &IpAddr, intf: &Interface) -> bool {
+pub(crate) fn valid_ip_on_intf(addr: &IpAddr, intf: &Interface) -> bool {
     match (addr, &intf.addr) {
         (IpAddr::V4(addr), IfAddr::V4(intf)) => {
             let netmask = u32::from(intf.netmask);

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -681,6 +681,81 @@ fn service_with_ipv4_only() {
 }
 
 #[test]
+fn test_disable_interface_cache() {
+    // Create a server
+    let server = ServiceDaemon::new().expect("Failed to create the server");
+
+    // Register a service with one IPv4.
+    let ty_domain = "_disable-intf._tcp.local.";
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap();
+    let instance_name = now.as_micros().to_string();
+    let service_ip_addr = my_ip_interfaces()
+        .iter()
+        .find(|iface| iface.ip().is_ipv4())
+        .map(|iface| iface.ip())
+        .unwrap();
+
+    let host_name = "disabled_intf_host.local.";
+    let port = 5201;
+    let my_service = ServiceInfo::new(
+        &ty_domain,
+        &instance_name,
+        host_name,
+        &service_ip_addr,
+        port,
+        None,
+    )
+    .expect("Invalid service info");
+    server
+        .register(my_service)
+        .expect("Failed to register our service");
+
+    // Create a client
+    let client = ServiceDaemon::new().expect("Failed to create the client");
+
+    // Give it some time to cache mDNS records.
+    sleep(Duration::from_secs(1));
+
+    // Disable the interface for the client.
+    client.disable_interface(service_ip_addr).unwrap();
+
+    // Browse for the service.
+    let handle = client.browse(&ty_domain).unwrap();
+    let timeout = Duration::from_secs(1);
+    let mut resolved = false;
+
+    // run till timeout and it should not resolve.
+    loop {
+        match handle.recv_timeout(timeout) {
+            Ok(event) => match event {
+                ServiceEvent::ServiceResolved(info) => {
+                    println!(
+                        "Resolved a service of {} addr(s): {:?}",
+                        &info.get_fullname(),
+                        info.get_addresses()
+                    );
+                    resolved = true;
+                    break;
+                }
+                _ => {}
+            },
+            Err(_) => {
+                break;
+            }
+        }
+    }
+
+    // We cannot resolve the service because the interface is disabled.
+    assert!(!resolved);
+
+    // Clean up.
+    server.shutdown().unwrap();
+    client.shutdown().unwrap();
+}
+
+#[test]
 fn service_with_invalid_addr_v4() {
     // Create a daemon
     let d = ServiceDaemon::new().expect("Failed to create daemon");

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -2097,7 +2097,7 @@ fn test_multicast_loop_v6() {
     let server = ServiceDaemon::new().expect("failed to start server");
     server.set_multicast_loop_v6(false).unwrap();
 
-    // Get a single IPv4 address
+    // Get a single IPv6 address
     let ip_addr1 = my_ip_interfaces()
         .iter()
         .find(|iface| iface.ip().is_ipv6())


### PR DESCRIPTION
This is a follow up fix of PR #296, and in turn issue #295 .

There are two changes:
1.  there is a timing window between starting a daemon and disabling an interface. The cache could already have stored some addresses before an interface is disabled. To make sure such address will be not resolved, we need to remove them when the interface is disabled.

2. On Linux, tests show that when multicast packets loop back, they are received by all interfaces that joined the multicast group, not just the original interface that sent the packet. As the result, interfaces of different network would also get the packet.  This behavior impact this PR as both server and client are running on the same host, and all multicast packets loop back (by default). Hence added a check against such case.
