### PR TITLE
enable_interface: support loopback interface

### DIFF
--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -179,7 +179,7 @@ impl DnsCache {
         if incoming.get_type() == RRType::A || incoming.get_type() == RRType::AAAA {
             if let Some(answer_addr) = incoming.any().downcast_ref::<DnsAddress>() {
                 let addr = answer_addr.address();
-                if !valid_ip_on_intf(&addr, intf) && !addr.is_loopback() {
+                if !valid_ip_on_intf(&addr, intf) {
                     debug!(
                         "add_or_update: answer addr {addr} not in the subnet of {}",
                         intf.ip()

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -291,9 +291,7 @@ impl ServiceInfo {
     pub(crate) fn get_addrs_on_intf(&self, intf: &Interface) -> Vec<IpAddr> {
         self.addresses
             .iter()
-            // Allow loopback addresses to support registering services on loopback interfaces,
-            // which is required by some use cases (e.g., OSCQuery) that publish via mDNS.
-            .filter(|a| (a.is_loopback() || valid_ip_on_intf(a, intf)))
+            .filter(|a| valid_ip_on_intf(a, intf))
             .copied()
             .collect()
     }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -874,6 +874,9 @@ fn service_with_loopback_addr() {
     // Create a daemon
     let d = ServiceDaemon::new().expect("Failed to create daemon");
 
+    d.enable_interface(IfKind::LoopbackV4)
+        .expect("Failed to enable loopback interface");
+
     // Define a unique service type and instance name.
     let ty_domain = "_test-loopback._tcp.local.";
     let now = SystemTime::now()


### PR DESCRIPTION
This is a follow-up patch of PR #307 .  The idea here is to use existing `enable_interface` to support loopback interfaces.
