### PR TITLE
feat: add boxed in DnsRecordExt to reduce Box::new usage

### DIFF
--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -1093,7 +1093,7 @@ impl DnsRegistry {
                 record.get_type(),
                 record.get_name()
             );
-            probe.insert_record(Box::new(record));
+            probe.insert_record(record.boxed());
         }
 
         new_timer_added


### PR DESCRIPTION
This is the equivalent of `DnsRecordExt::clone_box` but consuming.