### PR TITLE
chore(deps): update fastrand and socket2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,15 @@ logging = ["log"]
 default = ["async", "logging"]
 
 [dependencies]
-fastrand = "2.1"
+fastrand = "2.3"
 flume = { version = "0.11", default-features = false } # channel between threads
 if-addrs = { version = "0.13", features = ["link-local"] } # get local IP addresses
 log = { version = "0.4", optional = true }             # logging
 mio = { version = "1.0", features = ["os-poll", "net"] }  # select/poll sockets
-socket2 = { version = "0.5.5", features = ["all"] }      # socket APIs
+socket2 = { version = "0.5.8", features = ["all"] }      # socket APIs
 
 [dev-dependencies]
-env_logger = { version = "= 0.10.2", default-features = false, features= ["humantime"] }
-fastrand = "2.1"
+env_logger = { version = "= 0.11.6", default-features = false, features= ["humantime"] }
+fastrand = "2.3"
 humantime = "2.1"
-test-log = "= 0.2.14"
-test-log-macros = "= 0.2.14"
+test-log = "= 0.2.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ mio = { version = "1.0", features = ["os-poll", "net"] }  # select/poll sockets
 socket2 = { version = "0.5.8", features = ["all"] }      # socket APIs
 
 [dev-dependencies]
-env_logger = { version = "= 0.11.6", default-features = false, features= ["humantime"] }
 fastrand = "2.3"
 humantime = "2.1"
-test-log = "= 0.2.17"
+test-log = "0.2.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ mio = { version = "1.0", features = ["os-poll", "net"] }  # select/poll sockets
 socket2 = { version = "0.5.8", features = ["all"] }      # socket APIs
 
 [dev-dependencies]
-env_logger = { version = "0.11", default-features = false, features= ["humantime"] }
+env_logger = { version = "= 0.10.2", default-features = false, features= ["humantime"] }
 fastrand = "2.3"
 humantime = "2.1"
-test-log = "0.2.17"
+test-log = "= 0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ mio = { version = "1.0", features = ["os-poll", "net"] }  # select/poll sockets
 socket2 = { version = "0.5.8", features = ["all"] }      # socket APIs
 
 [dev-dependencies]
+env_logger = { version = "= 0.10.2", default-features = false, features= ["humantime"] }
 fastrand = "2.3"
 humantime = "2.1"
-test-log = "0.2.17"
+test-log = "= 0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ mio = { version = "1.0", features = ["os-poll", "net"] }  # select/poll sockets
 socket2 = { version = "0.5.8", features = ["all"] }      # socket APIs
 
 [dev-dependencies]
-env_logger = { version = "= 0.11.6", default-features = false, features= ["humantime"] }
+env_logger = { version = "0.11", default-features = false, features= ["humantime"] }
 fastrand = "2.3"
 humantime = "2.1"
-test-log = "= 0.2.17"
+test-log = "0.2.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ mio = { version = "1.0", features = ["os-poll", "net"] }  # select/poll sockets
 socket2 = { version = "0.5.8", features = ["all"] }      # socket APIs
 
 [dev-dependencies]
-env_logger = { version = "0.11", default-features = false, features= ["humantime"] }
+env_logger = { version = "0.10", default-features = false, features= ["humantime"] }
 fastrand = "2.3"
 humantime = "2.1"
 test-log = "0.2.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ mio = { version = "1.0", features = ["os-poll", "net"] }  # select/poll sockets
 socket2 = { version = "0.5.8", features = ["all"] }      # socket APIs
 
 [dev-dependencies]
-env_logger = { version = "= 0.10.2", default-features = false, features= ["humantime"] }
+env_logger = { version = "= 0.11.6", default-features = false, features= ["humantime"] }
 fastrand = "2.3"
 humantime = "2.1"
-test-log = "= 0.2.14"
+test-log = "= 0.2.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ env_logger = { version = "= 0.10.2", default-features = false, features= ["human
 fastrand = "2.3"
 humantime = "2.1"
 test-log = "= 0.2.14"
+test-log-macros = "= 0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ mio = { version = "1.0", features = ["os-poll", "net"] }  # select/poll sockets
 socket2 = { version = "0.5.8", features = ["all"] }      # socket APIs
 
 [dev-dependencies]
-env_logger = { version = "0.10", default-features = false, features= ["humantime"] }
+env_logger = { version = "0.11", default-features = false, features= ["humantime"] }
 fastrand = "2.3"
 humantime = "2.1"
 test-log = "0.2.17"

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -16,7 +16,7 @@
 use mdns_sd::{ServiceDaemon, ServiceEvent};
 
 fn main() {
-    env_logger::builder().format_timestamp_millis().init();
+    test_log::env_logger::builder().format_timestamp_millis().init();
 
     // Create a daemon
     let mdns = ServiceDaemon::new().expect("Failed to create daemon");

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -16,7 +16,9 @@
 use mdns_sd::{ServiceDaemon, ServiceEvent};
 
 fn main() {
-    test_log::env_logger::builder().format_timestamp_millis().init();
+    test_log::env_logger::builder()
+        .format_timestamp_millis()
+        .init();
 
     // Create a daemon
     let mdns = ServiceDaemon::new().expect("Failed to create daemon");

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -16,9 +16,7 @@
 use mdns_sd::{ServiceDaemon, ServiceEvent};
 
 fn main() {
-    env_logger::builder()
-        .format_timestamp_millis()
-        .init();
+    env_logger::builder().format_timestamp_millis().init();
 
     // Create a daemon
     let mdns = ServiceDaemon::new().expect("Failed to create daemon");

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -16,7 +16,7 @@
 use mdns_sd::{ServiceDaemon, ServiceEvent};
 
 fn main() {
-    test_log::env_logger::builder()
+    env_logger::builder()
         .format_timestamp_millis()
         .init();
 


### PR DESCRIPTION
I'd like for this to be merged mainly due to `socket2` updating `windows-sys` from `0.48` to `0.52`, thus getting rid of a repeated dependency in my project (due to other packages using the newer version).

This PR also updates `fastrand` in dev-dependencies ~~and removes 'test-log-macros' as it is unused.~~ (edit: not yet)