### PR TITLE
bugfix: when now equals next_ip_check

### DIFF
--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -651,8 +651,8 @@ impl ServiceDaemon {
             // Send out probing queries.
             zc.probing_handler();
 
-            // check IP changes.
-            if now > next_ip_check && next_ip_check > 0 {
+            // check IP changes if next_ip_check is reached.
+            if now >= next_ip_check && next_ip_check > 0 {
                 next_ip_check = now + zc.ip_check_interval;
                 zc.add_timer(next_ip_check);
 


### PR DESCRIPTION
This is to fix issue #322 . I reproduced the issue locally and found that it would happen if `now` equals `next_ip_check` and skips the IP changes check. Hence the diff.  I no longer see the issue with the fix. 

