### PR TITLE
test case-insensitivity in hostname

### DIFF
--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -96,9 +96,10 @@ impl DnsCache {
     /// Note that the keys in the returned HashMap are the same hostname, with different cases
     /// of letters (e.g. "example.local.", "Example.local.", "EXAMPLE.local.").
     pub(crate) fn get_addresses_for_host(&self, host: &str) -> HashMap<String, HashSet<IpAddr>> {
+        let hostname_lower = host.to_lowercase();
         let mut result = HashMap::new();
 
-        if let Some(records) = self.addr.get(host) {
+        if let Some(records) = self.addr.get(&hostname_lower) {
             for record in records {
                 if let Some(dns_addr) = record.any().downcast_ref::<DnsAddress>() {
                     let record_name = record.get_name().to_string();

--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -26,7 +26,7 @@ pub(crate) struct DnsCache {
     /// DnsTxt records indexed by the fullname of an instance
     txt: HashMap<String, Vec<DnsRecordBox>>,
 
-    /// DnsAddr records indexed by the hostname
+    /// DnsAddr records indexed by the hostname in lowercase.
     addr: HashMap<String, Vec<DnsRecordBox>>,
 
     /// A reverse lookup table from "instance fullname" to "subtype PTR name"
@@ -91,19 +91,26 @@ impl DnsCache {
             .collect()
     }
 
-    /// Returns the set of IP addresses for a hostname.
-    pub(crate) fn get_addresses_for_host(&self, host: &str) -> HashSet<IpAddr> {
-        self.addr
-            .get(host)
-            .into_iter()
-            .flatten()
-            .filter_map(|record| {
-                record
-                    .any()
-                    .downcast_ref::<DnsAddress>()
-                    .map(|addr| addr.address())
-            })
-            .collect()
+    /// Returns a hashmap of hostnames and their addresses for a given `host`.
+    pub(crate) fn get_addresses_for_host(&self, host: &str) -> HashMap<String, HashSet<IpAddr>> {
+        let mut result = HashMap::new();
+
+        if let Some(records) = self.addr.get(host) {
+            for record in records {
+                if let Some(dns_addr) = record.any().downcast_ref::<DnsAddress>() {
+                    let record_name = record.get_name().to_string();
+                    let address = dns_addr.address();
+
+                    // Use the entry API to insert or update the HashSet for the record_name
+                    result
+                        .entry(record_name)
+                        .or_insert_with(HashSet::new)
+                        .insert(address);
+                }
+            }
+        }
+
+        result
     }
 
     /// Returns a list of resource records (name, rr_type) that need to be queried in order to
@@ -190,11 +197,12 @@ impl DnsCache {
         }
 
         // get the existing records for the type.
+        let entry_name_lower = entry_name.to_lowercase();
         let record_vec = match incoming.get_type() {
             RRType::PTR => self.ptr.entry(entry_name).or_default(),
             RRType::SRV => self.srv.entry(entry_name).or_default(),
             RRType::TXT => self.txt.entry(entry_name).or_default(),
-            RRType::A | RRType::AAAA => self.addr.entry(entry_name).or_default(),
+            RRType::A | RRType::AAAA => self.addr.entry(entry_name_lower).or_default(),
             RRType::NSEC => self.nsec.entry(entry_name).or_default(),
             _ => return None,
         };

--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -92,6 +92,9 @@ impl DnsCache {
     }
 
     /// Returns a hashmap of hostnames and their addresses for a given `host`.
+    ///
+    /// Note that the keys in the returned HashMap are the same hostname, with different cases
+    /// of letters (e.g. "example.local.", "Example.local.", "EXAMPLE.local.").
     pub(crate) fn get_addresses_for_host(&self, host: &str) -> HashMap<String, HashSet<IpAddr>> {
         let mut result = HashMap::new();
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -3195,7 +3195,7 @@ fn call_hostname_resolution_listener(
     let hostname_lower = hostname.to_lowercase();
     if let Some(listener) = listeners_map.get(&hostname_lower).map(|(l, _)| l) {
         match listener.send(event) {
-            Ok(()) => debug!("Sent event to listener successfully"),
+            Ok(()) => trace!("Sent event to listener successfully"),
             Err(e) => debug!("Failed to send event: {}", e),
         }
     }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1811,8 +1811,7 @@ impl Zeroconf {
         hostname: &str,
         sender: Sender<HostnameResolutionEvent>,
     ) {
-        let hostname_lower = hostname.to_lowercase();
-        let addresses_map = self.cache.get_addresses_for_host(&hostname_lower);
+        let addresses_map = self.cache.get_addresses_for_host(hostname);
         for (name, addresses) in addresses_map {
             match sender.send(HostnameResolutionEvent::AddressesFound(name, addresses)) {
                 Ok(()) => trace!("sent hostname addresses found"),
@@ -2039,8 +2038,7 @@ impl Zeroconf {
             .iter()
             .filter(|change| change.ty == RRType::A || change.ty == RRType::AAAA)
         {
-            let hostname_lower = change.name.to_lowercase();
-            let addr_map = self.cache.get_addresses_for_host(&hostname_lower);
+            let addr_map = self.cache.get_addresses_for_host(&change.name);
             for (name, addresses) in addr_map {
                 call_hostname_resolution_listener(
                     &self.hostname_resolvers,

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -910,6 +910,7 @@ struct Zeroconf {
     /// Active "ResolveHostname" commands.
     ///
     /// The timestamps are set at the future timestamp when the command should timeout.
+    /// `hostname` is case-insensitive and stored in lowercase.
     hostname_resolvers: HashMap<String, (Sender<HostnameResolutionEvent>, Option<u64>)>, // <hostname, (channel::sender, UNIX timestamp in millis)>
 
     /// All repeating transmissions.
@@ -1609,7 +1610,7 @@ impl Zeroconf {
     ) {
         let real_timeout = timeout.map(|t| current_time_millis() + t);
         self.hostname_resolvers
-            .insert(hostname, (listener, real_timeout));
+            .insert(hostname.to_lowercase(), (listener, real_timeout));
         if let Some(t) = real_timeout {
             self.add_timer(t);
         }
@@ -1810,12 +1811,10 @@ impl Zeroconf {
         hostname: &str,
         sender: Sender<HostnameResolutionEvent>,
     ) {
-        let addresses = self.cache.get_addresses_for_host(hostname);
-        if !addresses.is_empty() {
-            match sender.send(HostnameResolutionEvent::AddressesFound(
-                hostname.to_string(),
-                addresses,
-            )) {
+        let hostname_lower = hostname.to_lowercase();
+        let addresses_map = self.cache.get_addresses_for_host(&hostname_lower);
+        for (name, addresses) in addresses_map {
+            match sender.send(HostnameResolutionEvent::AddressesFound(name, addresses)) {
                 Ok(()) => trace!("sent hostname addresses found"),
                 Err(e) => debug!("failed to send hostname addresses found: {}", e),
             }
@@ -2036,20 +2035,20 @@ impl Zeroconf {
         }
 
         // Go through remaining changes to see if any hostname resolutions were found or updated.
-        changes
+        for change in changes
             .iter()
             .filter(|change| change.ty == RRType::A || change.ty == RRType::AAAA)
-            .map(|change| change.name.clone())
-            .collect::<HashSet<String>>()
-            .iter()
-            .map(|hostname| (hostname, self.cache.get_addresses_for_host(hostname)))
-            .for_each(|(hostname, addresses)| {
+        {
+            let hostname_lower = change.name.to_lowercase();
+            let addr_map = self.cache.get_addresses_for_host(&hostname_lower);
+            for (name, addresses) in addr_map {
                 call_hostname_resolution_listener(
                     &self.hostname_resolvers,
-                    hostname,
-                    HostnameResolutionEvent::AddressesFound(hostname.to_string(), addresses),
+                    &change.name,
+                    HostnameResolutionEvent::AddressesFound(name, addresses),
                 )
-            });
+            }
+        }
 
         // Identify the instances that need to be "resolved".
         let mut updated_instances = HashSet::new();
@@ -2368,7 +2367,7 @@ impl Zeroconf {
                                 out.add_answer(
                                     &msg,
                                     DnsAddress::new(
-                                        question.entry_name(),
+                                        service_hostname,
                                         ip_address_rr_type(&address),
                                         CLASS_IN | CLASS_CACHE_FLUSH,
                                         service.get_host_ttl(),
@@ -2544,7 +2543,7 @@ impl Zeroconf {
             Command::StopBrowse(ty_domain) => self.exec_command_stop_browse(ty_domain),
 
             Command::StopResolveHostname(hostname) => {
-                self.exec_command_stop_resolve_hostname(hostname)
+                self.exec_command_stop_resolve_hostname(hostname.to_lowercase())
             }
 
             Command::Resolve(instance, try_count) => self.exec_command_resolve(instance, try_count),
@@ -3193,9 +3192,10 @@ fn call_hostname_resolution_listener(
     hostname: &str,
     event: HostnameResolutionEvent,
 ) {
-    if let Some(listener) = listeners_map.get(hostname).map(|(l, _)| l) {
+    let hostname_lower = hostname.to_lowercase();
+    if let Some(listener) = listeners_map.get(&hostname_lower).map(|(l, _)| l) {
         match listener.send(event) {
-            Ok(()) => trace!("Sent event to listener successfully"),
+            Ok(()) => debug!("Sent event to listener successfully"),
             Err(e) => debug!("Failed to send event: {}", e),
         }
     }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1319,7 +1319,7 @@ fn test_shutdown() {
 #[test]
 fn test_hostname_resolution() {
     let d = ServiceDaemon::new().expect("Failed to create daemon");
-    let hostname = "my_host._tcp.local.";
+    let hostname = "My_test_HOST.local.";
     let service_ip_addr = my_ip_interfaces()
         .iter()
         .find(|iface| iface.ip().is_ipv4())
@@ -1337,16 +1337,17 @@ fn test_hostname_resolution() {
     .expect("invalid service info");
     d.register(my_service).unwrap();
 
-    let event_receiver = d.resolve_hostname(hostname, Some(2000)).unwrap();
+    let hostname_lower = hostname.to_lowercase();
+    let event_receiver = d.resolve_hostname(&hostname_lower, Some(2000)).unwrap();
     let resolved = loop {
         match event_receiver.recv() {
             Ok(HostnameResolutionEvent::AddressesFound(found_hostname, addresses)) => {
-                assert!(found_hostname == hostname);
+                assert!(found_hostname == hostname_lower);
                 assert!(addresses.contains(&service_ip_addr));
                 break true;
             }
             Ok(HostnameResolutionEvent::SearchStopped(_)) => break false,
-            Ok(event) => println!("Received event {:?}", event),
+            Ok(_event) => {},
             Err(_) => break false,
         }
     };

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1366,7 +1366,7 @@ fn test_hostname_resolution_case_insensitive() {
         .unwrap();
 
     let my_service = ServiceInfo::new(
-        "_host_res_test._tcp.local.",
+        "_host_case_test._tcp.local.",
         "my_instance",
         hostname,
         &[service_ip_addr] as &[IpAddr],

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1347,7 +1347,7 @@ fn test_hostname_resolution() {
                 break true;
             }
             Ok(HostnameResolutionEvent::SearchStopped(_)) => break false,
-            Ok(_event) => {},
+            Ok(_event) => {}
             Err(_) => break false,
         }
     };


### PR DESCRIPTION
This is to help fix issue #329 . The modified test shows that we are resolving hostname with case-insensitivity, but the returned hostname is the hostname in the query, not the original hostname registered by the server.

The fix is: 
- Always respond the original hostname registered by the service on server side.
- In DnsCache, use lowercase hostname to index the records of host addresses, with the original hostname stored in each record.
