### PR TITLE
bugfix: make `get_addr` method use lowercase hostname

### DIFF
--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -66,7 +66,7 @@ impl DnsCache {
     }
 
     pub(crate) fn get_addr(&self, hostname: &str) -> Option<&Vec<DnsRecordBox>> {
-        self.addr.get(hostname)
+        self.addr.get(&hostname.to_lowercase())
     }
 
     /// A reverse lookup table from "instance fullname" to "subtype PTR name"

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -54,7 +54,7 @@ fn integration_success() {
         println!("{}", &item);
     }
 
-    let host_name = "integration_host.local.";
+    let host_name = "INTEGRATION_host.local.";
     let port = 5200;
     let mut properties = HashMap::new();
     properties.insert("property_1".to_string(), "test".to_string());


### PR DESCRIPTION
In the last pull request regarding the lowercase hostname topic, the resolution of services was broken.

The version `0.13.4` should probably be yanked, to avoid updates where suddenly resolving of services is broken.

I have also adjusted the integration test, so it would have catched this case.