### PR TITLE
ServiceDaemon: new method to clear cached DNS records

### DIFF
--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -576,6 +576,16 @@ impl DnsCache {
             });
         }
     }
+
+    /// Flush the cache for all records.
+    pub(crate) fn clear(&mut self) {
+        self.ptr.clear();
+        self.srv.clear();
+        self.txt.clear();
+        self.addr.clear();
+        self.subtype.clear();
+        self.nsec.clear();
+    }
 }
 
 /// Returns UNIX time in millis

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -438,9 +438,6 @@ impl ServiceDaemon {
     ///
     /// Which means, in order NOT to receive localhost announcements, you want to call
     /// this API on the querier side on Windows, but on the responder side on Unix.
-    ///
-    /// Note: when called on the client side, to make sure no loopback datagrams are already
-    /// received and cached, please call [`Self::clear_cache`] after this method.
     pub fn set_multicast_loop_v4(&self, on: bool) -> Result<()> {
         self.send_cmd(Command::SetOption(DaemonOption::MulticastLoopV4(on)))
     }
@@ -460,9 +457,6 @@ impl ServiceDaemon {
     ///
     /// Which means, in order NOT to receive localhost announcements, you want to call
     /// this API on the querier side on Windows, but on the responder side on Unix.
-    ///
-    /// Note: when called on the client side, to make sure no loopback datagrams are already
-    /// received and cached, please call [`Self::clear_cache`] after this method.
     pub fn set_multicast_loop_v6(&self, on: bool) -> Result<()> {
         self.send_cmd(Command::SetOption(DaemonOption::MulticastLoopV6(on)))
     }
@@ -488,7 +482,8 @@ impl ServiceDaemon {
     /// This is useful when you changed some configurations and want to make sure
     /// the daemon has a clean slate without any stale records.
     ///
-    /// For example: `daemon.set_multicast_loop_v6(false)` and then call this method.
+    /// For example: `daemon.set_multicast_loop_v6(false)` changes the daemon's configuration,
+    /// and then call this method before browsing a service.
     pub fn clear_cache(&self) -> Result<()> {
         self.send_cmd(Command::ClearCache)
     }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -438,6 +438,9 @@ impl ServiceDaemon {
     ///
     /// Which means, in order NOT to receive localhost announcements, you want to call
     /// this API on the querier side on Windows, but on the responder side on Unix.
+    ///
+    /// Note: when called on the client side, to make sure no loopback datagrams are already
+    /// received and cached, please call [`Self::clear_cache`] after this method.
     pub fn set_multicast_loop_v4(&self, on: bool) -> Result<()> {
         self.send_cmd(Command::SetOption(DaemonOption::MulticastLoopV4(on)))
     }
@@ -457,6 +460,9 @@ impl ServiceDaemon {
     ///
     /// Which means, in order NOT to receive localhost announcements, you want to call
     /// this API on the querier side on Windows, but on the responder side on Unix.
+    ///
+    /// Note: when called on the client side, to make sure no loopback datagrams are already
+    /// received and cached, please call [`Self::clear_cache`] after this method.
     pub fn set_multicast_loop_v6(&self, on: bool) -> Result<()> {
         self.send_cmd(Command::SetOption(DaemonOption::MulticastLoopV6(on)))
     }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -2259,6 +2259,9 @@ fn test_multicast_loop_v6() {
     // For Windows, IP_MULTICAST_LOOP option works only on the receive path.
     client.set_multicast_loop_v6(false).unwrap();
 
+    // Make sure no stale records are in the cache before config changes.
+    client.clear_cache().unwrap();
+
     let receiver = client.browse(ty_domain).unwrap();
 
     let timeout = Duration::from_secs(2);


### PR DESCRIPTION
This patch is trying to resolve issue #308 .  One thing I'm not sure is that this lib did not expose the concept of `cache` before. I'm wondering if `clear_cache()` should be called something else so that existing users can understand more easily.