### PR TITLE
feat: extend `DnsAddress` with an `InterfaceId`

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -22,7 +22,7 @@ use std::{
     time::SystemTime,
 };
 
-/// InterfaceId is used to represent the interface indentifer
+/// InterfaceId is used to represent the interface identifier
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct InterfaceId {
     name: String,

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -9,6 +9,8 @@ use crate::log::trace;
 
 use crate::error::{e_fmt, Error, Result};
 
+use if_addrs::Interface;
+
 use std::{
     any::Any,
     cmp,
@@ -19,6 +21,34 @@ use std::{
     str,
     time::SystemTime,
 };
+
+/// InterfaceId is used to represent the interface indentifer
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct InterfaceId {
+    name: String,
+    index: u32,
+}
+
+impl InterfaceId {
+    pub fn index(&self) -> u32 {
+        self.index
+    }
+}
+
+impl fmt::Display for InterfaceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.index, self.name)
+    }
+}
+
+impl From<&Interface> for InterfaceId {
+    fn from(interface: &Interface) -> Self {
+        InterfaceId {
+            name: interface.name.clone(),
+            index: interface.index.unwrap_or_default(),
+        }
+    }
+}
 
 /// DNS resource record types, stored as `u16`. Can do `as u16` when needed.
 ///
@@ -485,12 +515,24 @@ pub trait DnsRecordExt: fmt::Debug {
 pub struct DnsAddress {
     pub(crate) record: DnsRecord,
     address: IpAddr,
+    interface_id: InterfaceId,
 }
 
 impl DnsAddress {
-    pub fn new(name: &str, ty: RRType, class: u16, ttl: u32, address: IpAddr) -> Self {
+    pub fn new(
+        name: &str,
+        ty: RRType,
+        class: u16,
+        ttl: u32,
+        address: IpAddr,
+        interface_id: InterfaceId,
+    ) -> Self {
         let record = DnsRecord::new(name, ty, class, ttl);
-        Self { record, address }
+        Self {
+            record,
+            address,
+            interface_id,
+        }
     }
 
     pub fn address(&self) -> IpAddr {
@@ -520,7 +562,9 @@ impl DnsRecordExt for DnsAddress {
 
     fn matches(&self, other: &dyn DnsRecordExt) -> bool {
         if let Some(other_a) = other.any().downcast_ref::<Self>() {
-            return self.address == other_a.address && self.record.entry == other_a.record.entry;
+            return self.address == other_a.address
+                && self.record.entry == other_a.record.entry
+                && self.interface_id == other_a.interface_id;
         }
         false
     }
@@ -1661,10 +1705,11 @@ pub struct DnsIncoming {
     num_answers: u16,
     num_authorities: u16,
     num_additionals: u16,
+    interface_id: InterfaceId,
 }
 
 impl DnsIncoming {
-    pub fn new(data: Vec<u8>) -> Result<Self> {
+    pub fn new(data: Vec<u8>, interface_id: InterfaceId) -> Result<Self> {
         let mut incoming = Self {
             offset: 0,
             data,
@@ -1678,6 +1723,7 @@ impl DnsIncoming {
             num_answers: 0,
             num_authorities: 0,
             num_additionals: 0,
+            interface_id,
         };
 
         /*
@@ -1945,12 +1991,26 @@ impl DnsIncoming {
                         .boxed(),
                     ),
                     RRType::A => Some(
-                        DnsAddress::new(&name, rr_type, class, ttl, self.read_ipv4()?.into())
-                            .boxed(),
+                        DnsAddress::new(
+                            &name,
+                            rr_type,
+                            class,
+                            ttl,
+                            self.read_ipv4()?.into(),
+                            self.interface_id.clone(),
+                        )
+                        .boxed(),
                     ),
                     RRType::AAAA => Some(
-                        DnsAddress::new(&name, rr_type, class, ttl, self.read_ipv6()?.into())
-                            .boxed(),
+                        DnsAddress::new(
+                            &name,
+                            rr_type,
+                            class,
+                            ttl,
+                            self.read_ipv6()?.into(),
+                            self.interface_id.clone(),
+                        )
+                        .boxed(),
                     ),
                     RRType::NSEC => Some(
                         DnsNSec::new(

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -3115,7 +3115,7 @@ enum Command {
     /// Get the current status of the daemon.
     GetStatus(Sender<DaemonStatus>),
 
-    /// Monitor noticable events in the daemon.
+    /// Monitor noticeable events in the daemon.
     Monitor(Sender<DaemonEvent>),
 
     SetOption(DaemonOption),

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1618,6 +1618,7 @@ impl Zeroconf {
                     CLASS_IN | CLASS_CACHE_FLUSH,
                     0,
                     address,
+                    intf.into(),
                 ),
                 0,
             );
@@ -1741,7 +1742,7 @@ impl Zeroconf {
 
         buf.truncate(sz); // reduce potential processing errors
 
-        match DnsIncoming::new(buf) {
+        match DnsIncoming::new(buf, intf.into()) {
             Ok(msg) => {
                 if msg.is_query() {
                     self.handle_query(msg, intf);
@@ -2397,6 +2398,7 @@ impl Zeroconf {
                                         CLASS_IN | CLASS_CACHE_FLUSH,
                                         service.get_host_ttl(),
                                         address,
+                                        intf.into(),
                                     ),
                                 );
                             }
@@ -2468,6 +2470,7 @@ impl Zeroconf {
                             CLASS_IN | CLASS_CACHE_FLUSH,
                             service.get_host_ttl(),
                             address,
+                            intf.into(),
                         ));
                     }
                 }
@@ -3465,6 +3468,7 @@ fn prepare_announce(
             CLASS_IN | CLASS_CACHE_FLUSH,
             info.get_host_ttl(),
             address,
+            intf.into(),
         );
 
         if let Some(new_name) = dns_registry.name_changes.get(hostname) {
@@ -3643,6 +3647,7 @@ fn add_answer_with_additionals(
             CLASS_IN | CLASS_CACHE_FLUSH,
             service.get_host_ttl(),
             address,
+            intf.into(),
         ));
     }
 }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1621,7 +1621,7 @@ fn test_cache_flush_remove_one_addr() {
 
     // Stop browsing for a moment.
     client.stop_browse(service).unwrap();
-    sleep(Duration::from_secs(2)); // Wait 1 more second for the 2nd annoucement
+    sleep(Duration::from_secs(2)); // Wait 1 more second for the 2nd announcement
 
     // Re-register the service to have only 1 addr.
     my_service =


### PR DESCRIPTION
This allows for adding an interface scope to resolved IPv6 link local addresses to resolve #339 