### PR TITLE
remove address filter for multicast loopback

### DIFF
--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -211,21 +211,6 @@ impl DnsCache {
             }
         }
 
-        // Check if address is valid on the interface. When IP_MULTICAST_LOOP is enabled,
-        // a multicast packet would loopback to other interfaces of the same multicast group on Linux.
-        if incoming.get_type() == RRType::A || incoming.get_type() == RRType::AAAA {
-            if let Some(answer_addr) = incoming.any().downcast_ref::<DnsAddress>() {
-                let addr = answer_addr.address();
-                if !valid_ip_on_intf(&addr, intf) {
-                    debug!(
-                        "add_or_update: answer addr {addr} not in the subnet of {}",
-                        intf.ip()
-                    );
-                    return None;
-                }
-            }
-        }
-
         // get the existing records for the type.
         let entry_name_lower = entry_name.to_lowercase();
         let record_vec = match incoming.get_type() {


### PR DESCRIPTION
This patch is to fix issue #343 .  I think in long term, we would like to move towards supporting address (A and AAAA) records not limited by the responder interface subnet itself. So far, we've already seen two use cases:  1) this issue #343 and 2) using Loopback address (PR #317 )