### PR TITLE
bugfix: should keep A records for hostname queriers

### DIFF
--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -2013,6 +2013,13 @@ impl Zeroconf {
                 } else {
                     is_for_us = false;
                 }
+            } else if answer.get_type() == RRType::A || answer.get_type() == RRType::AAAA {
+                // If there is a hostname querier for this address, then it is for us.
+                let answer_lowercase = answer.get_name().to_lowercase();
+                if self.hostname_resolvers.contains_key(&answer_lowercase) {
+                    is_for_us = true;
+                    break; // OK to break: at least one hostname for us.
+                }
             }
         }
 


### PR DESCRIPTION
This is to address the test failure observed in [CI error](https://github.com/keepsimple1/mdns-sd/actions/runs/14610511006/job/40987554407). 

