### PR TITLE
bugfix: only remove a service instance if all its SRV are gone

### DIFF
--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -363,15 +363,16 @@ impl DnsCache {
                     if let Some(srv_records) = self.srv.get_mut(instance_name) {
                         srv_records.retain(|srv| {
                             let expired = srv.get_record().is_expired(now);
-                            if expired {
-                                trace!("expired SRV: {}: {:?}", ty_domain, srv);
-                                expired_instances
-                                    .entry(ty_domain.to_string())
-                                    .or_insert_with(HashSet::new)
-                                    .insert(srv.get_name().to_string());
-                            }
                             !expired
                         });
+
+                        if srv_records.is_empty() {
+                            trace!("expired SRV for {}: {:?}", ty_domain, instance_name);
+                            expired_instances
+                                .entry(ty_domain.to_string())
+                                .or_insert_with(HashSet::new)
+                                .insert(instance_name.to_string());
+                        }
                     }
 
                     // evict expired TXT records of this instance


### PR DESCRIPTION
This is to address issue #340 .  Its trace shows that SRV record was flushed and 1 second later removed (as expected). But the service instance was removed as well even there is a newer SRV record still in the cache: 

flush and old SRV expires:
```
[2025-04-14T12:08:25.156Z TRACE mdns_sd::dns_cache] FLUSH one record: DnsSrv { record: DnsRecord { entry: DnsEntry { name: "adb-43081FDAS000VS-qZDEu8._adb-tls-pairing._tcp.local.", ty: SRV, class: 1, cache_flush: true }, ttl: 120, created: 1744632490721, expires: 1744632610721, refresh: 1744632586721, new_name: None }, priority: 0, weight: 0, host: "Android_A0WCYA4K.local.", port: 39649 }
[2025-04-14T12:08:26.157Z TRACE mdns_sd::dns_cache] expired SRV: _adb-tls-pairing._tcp.local.: DnsSrv { record: DnsRecord { entry: DnsEntry { name: "adb-43081FDAS000VS-qZDEu8._adb-tls-pairing._tcp.local.", ty: SRV, class: 1, cache_flush: true }, ttl: 120, created: 1744632490721, expires: 1744632506156, refresh: 1744632586721, new_name: None }, priority: 0, weight: 0, host: "Android_A0WCYA4K.local.", port: 39649 }
```

new SRV record, with a different host name: 
```
[2025-04-14T12:08:25.187Z TRACE mdns_sd::dns_parser] read_rr_records: DnsSrv { record: DnsRecord { entry: DnsEntry { name: "adb-43081FDAS000VS-qZDEu8._adb-tls-pairing._tcp.local.", ty: SRV, class: 1, cache_flush: true }, ttl: 120, created: 1744632505187, expires: 1744632625187, refresh: 1744632601187, new_name: None }, priority: 0, weight: 0, host: "Android_QECP7A5H.local.", port: 40983 }
```

The patch is: when handling expired SRV records, only remove the service instance if its SRV list becomes empty. 
