### PR TITLE
bugfix: not to resolve records that expires soon

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -360,12 +360,12 @@ impl DnsRecord {
         self.ttl = other.ttl;
         self.created = other.created;
         self.expires = get_expiration_time(self.created, self.ttl, 100);
-        self.refresh = if self.ttl == 1 {
+        self.refresh = if self.ttl > 1 {
+            get_expiration_time(self.created, self.ttl, 80)
+        } else {
             // If TTL is 1, it means this record is expiring,
             // then we set refresh to the same time as expires.
             self.expires
-        } else {
-            get_expiration_time(self.created, self.ttl, 80)
         };
     }
 

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -282,6 +282,13 @@ impl DnsRecord {
         now >= self.expires
     }
 
+    /// Returns whether record expires in 1 second.
+    ///
+    /// This is useful because mDNS sets TTL to 1 (not 0) for expiring records.
+    pub const fn expires_soon(&self, now: u64) -> bool {
+        now + 1000 >= self.expires
+    }
+
     pub const fn refresh_due(&self, now: u64) -> bool {
         now >= self.refresh
     }
@@ -352,8 +359,14 @@ impl DnsRecord {
     fn reset_ttl(&mut self, other: &Self) {
         self.ttl = other.ttl;
         self.created = other.created;
-        self.refresh = get_expiration_time(self.created, self.ttl, 80);
         self.expires = get_expiration_time(self.created, self.ttl, 100);
+        self.refresh = if self.ttl == 1 {
+            // If TTL is 1, it means this record is expiring,
+            // then we set refresh to the same time as expires.
+            self.expires
+        } else {
+            get_expiration_time(self.created, self.ttl, 80)
+        };
     }
 
     /// Modify TTL to reflect the remaining life time from `now`.
@@ -477,6 +490,11 @@ pub trait DnsRecordExt: fmt::Debug {
         if expire_at < self.get_expire() {
             self.get_record_mut().set_expire(expire_at);
         }
+    }
+
+    /// Returns true if the record expires in 1 second from `now`.
+    fn expires_soon(&self, now: u64) -> bool {
+        self.get_record().expires_soon(now)
     }
 
     /// Given `now`, if the record is due to refresh, this method updates the refresh time

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1912,7 +1912,7 @@ impl Zeroconf {
             for answer in records.iter() {
                 if let Some(dns_a) = answer.any().downcast_ref::<DnsAddress>() {
                     if dns_a.expires_soon(now) {
-                        trace!("Addr expired: {}", dns_a.address());
+                        trace!("Addr expired or expires soon: {}", dns_a.address());
                     } else {
                         info.insert_ipaddr(dns_a.address());
                     }
@@ -2054,6 +2054,8 @@ impl Zeroconf {
 
                     let ty = dns_record.get_type();
                     let name = dns_record.get_name();
+
+                    // Only process PTR that does not expire soon (i.e. TTL > 1).
                     if ty == RRType::PTR && dns_record.get_record().get_ttl() > 1 {
                         if self.service_queriers.contains_key(name) {
                             timers.push(dns_record.get_record().get_refresh_time());


### PR DESCRIPTION
This is to fix issue #352 .  Currently we resolve service records even when its TTL is 1 and expires soon. This fix adds checks against such cases. Integration test is updated.
