### PR TITLE
bugfix: TXT records should use OTHER_TTL same as PTR

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -1494,6 +1494,11 @@ impl DnsOutgoing {
         &self.questions
     }
 
+    /// For testing purposes only.
+    pub(crate) fn _answers(&self) -> &[(DnsRecordBox, u64)] {
+        &self.answers
+    }
+
     pub fn answers_count(&self) -> usize {
         self.answers.len()
     }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -2455,7 +2455,7 @@ impl Zeroconf {
                         DnsTxt::new(
                             question.entry_name(),
                             CLASS_IN | CLASS_CACHE_FLUSH,
-                            service.get_host_ttl(),
+                            service.get_other_ttl(),
                             service.generate_txt(),
                         ),
                     );
@@ -3643,7 +3643,7 @@ fn add_answer_with_additionals(
     out.add_additional_answer(DnsTxt::new(
         service_fullname,
         CLASS_IN | CLASS_CACHE_FLUSH,
-        service.get_host_ttl(),
+        service.get_other_ttl(),
         service.generate_txt(),
     ));
 


### PR DESCRIPTION
This is found when debugging issue #351 .  `TXT` records are not refreshed by the client because the server sets TTL to be 120 seconds, which should be 4500 seconds as PTR records. 

I manually tested this diff and saw the issue #351 is gone. Will work on a test case. 

Update: added a test case and some refactoring.