### PR TITLE
feat: new API to use ResolvedService instead of ServiceInfo for resolved service event

### DIFF
--- a/examples/query.rs
+++ b/examples/query.rs
@@ -50,7 +50,7 @@ fn main() {
                     println!(
                         " Address: {} ({:?})",
                         addr,
-                        interfaces.iter().map(|i| i.name()).collect::<Vec<_>>()
+                        interfaces.iter().map(|i| &i.name).collect::<Vec<_>>()
                     );
                 }
                 for prop in info.txt_properties.iter() {

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -18,9 +18,6 @@ use mdns_sd::{ServiceDaemon, ServiceEvent};
 fn main() {
     env_logger::builder().format_timestamp_millis().init();
 
-    // Create a daemon
-    let mdns = ServiceDaemon::new().expect("Failed to create daemon");
-
     let mut service_type = match std::env::args().nth(1) {
         Some(arg) => arg,
         None => {
@@ -28,26 +25,35 @@ fn main() {
             return;
         }
     };
-
-    // Browse for a service type.
     service_type.push_str(".local.");
+
+    // Create a daemon
+    let mdns = ServiceDaemon::new().expect("Failed to create daemon");
+    mdns.use_service_detailed(true)
+        .expect("Failed to use service detailed");
+
+    // Browse for the service type
     let receiver = mdns.browse(&service_type).expect("Failed to browse");
 
     let now = std::time::Instant::now();
     while let Ok(event) = receiver.recv() {
         match event {
-            ServiceEvent::ServiceResolved(info) => {
+            ServiceEvent::ServiceDetailed(info) => {
                 println!(
                     "At {:?}: Resolved a new service: {}\n host: {}\n port: {}",
                     now.elapsed(),
-                    info.get_fullname(),
-                    info.get_hostname(),
-                    info.get_port(),
+                    info.fullname,
+                    info.host,
+                    info.port,
                 );
-                for addr in info.get_addresses().iter() {
-                    println!(" Address: {}", addr);
+                for (addr, interfaces) in info.addresses.iter() {
+                    println!(
+                        " Address: {} ({:?})",
+                        addr,
+                        interfaces.iter().map(|i| i.name()).collect::<Vec<_>>()
+                    );
                 }
-                for prop in info.get_properties().iter() {
+                for prop in info.txt_properties.iter() {
                     println!(" Property: {}", prop);
                 }
             }

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -46,12 +46,8 @@ fn main() {
                     info.host,
                     info.port,
                 );
-                for (addr, interfaces) in info.addresses.iter() {
-                    println!(
-                        " Address: {} ({:?})",
-                        addr,
-                        interfaces.iter().map(|i| &i.name).collect::<Vec<_>>()
-                    );
+                for addr in info.addresses.iter() {
+                    println!(" Address: {addr}");
                 }
                 for prop in info.txt_properties.iter() {
                     println!(" Property: {}", prop);

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -47,6 +47,83 @@ impl From<&Interface> for InterfaceId {
     }
 }
 
+/// An IPv4 address used in `HostIp`.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct HostIpV4 {
+    addr: Ipv4Addr,
+}
+
+/// An IPv6 address with scope_id (interface identifier).
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct HostIpV6 {
+    addr: Ipv6Addr,
+    scope_id: InterfaceId,
+}
+
+/// A host IP address, either IPv4 or IPv6, that supports scope_id for IPv6.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[non_exhaustive]
+pub enum HostIp {
+    V4(HostIpV4),
+    V6(HostIpV6),
+}
+
+impl HostIp {
+    pub const fn to_ip_addr(&self) -> IpAddr {
+        match self {
+            HostIp::V4(v4) => IpAddr::V4(v4.addr),
+            HostIp::V6(v6) => IpAddr::V6(v6.addr),
+        }
+    }
+
+    pub const fn is_ipv4(&self) -> bool {
+        matches!(self, HostIp::V4(_))
+    }
+
+    pub const fn is_ipv6(&self) -> bool {
+        matches!(self, HostIp::V6(_))
+    }
+}
+
+impl From<IpAddr> for HostIp {
+    fn from(ip: IpAddr) -> Self {
+        match ip {
+            IpAddr::V4(v4) => HostIp::V4(HostIpV4 { addr: v4 }),
+            IpAddr::V6(v6) => HostIp::V6(HostIpV6 {
+                addr: v6,
+                scope_id: InterfaceId::default(),
+            }),
+        }
+    }
+}
+
+impl From<&Interface> for HostIp {
+    fn from(interface: &Interface) -> Self {
+        match interface.ip() {
+            IpAddr::V4(v4) => HostIp::V4(HostIpV4 { addr: v4 }),
+            IpAddr::V6(v6) => HostIp::V6(HostIpV6 {
+                addr: v6,
+                scope_id: InterfaceId::from(interface),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for HostIp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HostIp::V4(v4) => write!(f, "{}", v4.addr),
+            HostIp::V6(v6) => {
+                if v6.scope_id.index != 0 {
+                    write!(f, "{}%{}", v6.addr, v6.scope_id.name)
+                } else {
+                    write!(f, "{}", v6.addr)
+                }
+            }
+        }
+    }
+}
+
 /// DNS resource record types, stored as `u16`. Can do `as u16` when needed.
 ///
 /// See [RFC 1035 section 3.2.2](https://datatracker.ietf.org/doc/html/rfc1035#section-3.2.2)
@@ -550,8 +627,14 @@ impl DnsAddress {
         }
     }
 
-    pub fn address(&self) -> IpAddr {
-        self.address
+    pub fn address(&self) -> HostIp {
+        match self.address {
+            IpAddr::V4(v4) => HostIp::V4(HostIpV4 { addr: v4 }),
+            IpAddr::V6(v6) => HostIp::V6(HostIpV6 {
+                addr: v6,
+                scope_id: self.interface_id.clone(),
+            }),
+        }
     }
 }
 

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -115,14 +115,7 @@ impl fmt::Display for HostIp {
             HostIp::V4(v4) => write!(f, "{}", v4.addr),
             HostIp::V6(v6) => {
                 if v6.scope_id.index != 0 {
-                    #[cfg(not(windows))]
-                    {
-                        write!(f, "{}%{}", v6.addr, v6.scope_id.name)
-                    }
-                    #[cfg(windows)]
-                    {
-                        write!(f, "{}%{}", v6.addr, v6.scope_id.index)
-                    }
+                    write!(f, "{}%{}", v6.addr, v6.scope_id.index)
                 } else {
                     write!(f, "{}", v6.addr)
                 }

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -22,26 +22,19 @@ use std::{
     time::SystemTime,
 };
 
-/// InterfaceId is used to represent the interface identifier
+/// Represents a network interface identifier defined by the OS.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Default)]
 pub struct InterfaceId {
-    name: String,
-    index: u32,
-}
+    /// Interface name, e.g. "en0", "wlan0", etc.
+    pub name: String,
 
-impl InterfaceId {
-    pub fn index(&self) -> u32 {
-        self.index
-    }
-
-    pub fn name(&self) -> &str {
-        &self.name
-    }
+    /// Interface index assigned by the OS, e.g. 1, 2, etc.
+    pub index: u32,
 }
 
 impl fmt::Display for InterfaceId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: {}", self.index, self.name)
+        write!(f, "{}(idx {})", self.name, self.index)
     }
 }
 

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -115,7 +115,14 @@ impl fmt::Display for HostIp {
             HostIp::V4(v4) => write!(f, "{}", v4.addr),
             HostIp::V6(v6) => {
                 if v6.scope_id.index != 0 {
-                    write!(f, "{}%{}", v6.addr, v6.scope_id.name)
+                    #[cfg(not(windows))]
+                    {
+                        write!(f, "{}%{}", v6.addr, v6.scope_id.name)
+                    }
+                    #[cfg(windows)]
+                    {
+                        write!(f, "{}%{}", v6.addr, v6.scope_id.index)
+                    }
                 } else {
                     write!(f, "{}", v6.addr)
                 }

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -23,7 +23,7 @@ use std::{
 };
 
 /// InterfaceId is used to represent the interface identifier
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Default)]
 pub struct InterfaceId {
     name: String,
     index: u32,
@@ -32,6 +32,10 @@ pub struct InterfaceId {
 impl InterfaceId {
     pub fn index(&self) -> u32 {
         self.index
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
     }
 }
 
@@ -555,6 +559,10 @@ impl DnsAddress {
 
     pub fn address(&self) -> IpAddr {
         self.address
+    }
+
+    pub fn interface_id(&self) -> &InterfaceId {
+        &self.interface_id
     }
 }
 

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -607,7 +607,7 @@ pub trait DnsRecordExt: fmt::Debug {
 pub struct DnsAddress {
     pub(crate) record: DnsRecord,
     address: IpAddr,
-    pub(crate) interface_id: InterfaceId,
+    interface_id: InterfaceId,
 }
 
 impl DnsAddress {

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -530,7 +530,7 @@ pub trait DnsRecordExt: fmt::Debug {
 pub struct DnsAddress {
     pub(crate) record: DnsRecord,
     address: IpAddr,
-    interface_id: InterfaceId,
+    pub(crate) interface_id: InterfaceId,
 }
 
 impl DnsAddress {
@@ -552,10 +552,6 @@ impl DnsAddress {
 
     pub fn address(&self) -> IpAddr {
         self.address
-    }
-
-    pub fn interface_id(&self) -> &InterfaceId {
-        &self.interface_id
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ mod error;
 mod service_daemon;
 mod service_info;
 
-pub use dns_parser::RRType;
+pub use dns_parser::{InterfaceId, RRType};
 pub use error::{Error, Result};
 pub use service_daemon::{
     DaemonEvent, DaemonStatus, DnsNameChange, HostnameResolutionEvent, IfKind, Metrics,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ mod error;
 mod service_daemon;
 mod service_info;
 
-pub use dns_parser::{InterfaceId, RRType};
+pub use dns_parser::{HostIp, HostIpV4, HostIpV6, InterfaceId, RRType};
 pub use error::{Error, Result};
 pub use service_daemon::{
     DaemonEvent, DaemonStatus, DnsNameChange, HostnameResolutionEvent, IfKind, Metrics,

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -39,8 +39,7 @@ use crate::{
     },
     error::{e_fmt, Error, Result},
     service_info::{
-        split_sub_domain, valid_ip_on_intf, DnsRegistry, Probe, ScopedAddr, ServiceInfo,
-        ServiceStatus,
+        split_sub_domain, valid_ip_on_intf, DnsRegistry, Probe, ServiceInfo, ServiceStatus,
     },
     Receiver, ResolvedService, TxtProperties,
 };
@@ -1912,7 +1911,7 @@ impl Zeroconf {
             fullname: fullname.to_string(),
             host: String::new(),
             port: 0,
-            addresses: HashSet::new(),
+            addresses: HashMap::new(),
             txt_properties: TxtProperties::new(),
         };
 
@@ -1955,9 +1954,11 @@ impl Zeroconf {
                     if dns_a.expires_soon(now) {
                         trace!("Addr expired or expires soon: {}", dns_a.address());
                     } else {
-                        let intf_addr =
-                            ScopedAddr::new(dns_a.address(), dns_a.interface_id().clone());
-                        resolved_service.addresses.insert(intf_addr);
+                        resolved_service
+                            .addresses
+                            .entry(dns_a.address())
+                            .or_default()
+                            .push(dns_a.interface_id().clone());
                     }
                 }
             }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -484,6 +484,8 @@ impl ServiceDaemon {
     }
 
     /// Enable or disable the use of [ServiceEvent::ServiceDetailed] instead of [ServiceEvent::ServiceResolved].
+    ///
+    /// This is recommended for clients using IPv6 as it will include scope_id in the address.
     pub fn use_service_detailed(&self, on: bool) -> Result<()> {
         self.send_cmd(Command::SetOption(DaemonOption::UseServiceDetailed(on)))
     }

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -1172,10 +1172,7 @@ pub struct ResolvedService {
     /// Port of the service. I.e. TCP or UDP port.
     pub port: u16,
 
-    /// Addresses of the service.
-    /// Each address maps to the list of interfaces on which the address is found.
-    /// The interface list is particularly useful for link-local IPv6 addresses,
-    /// where the same address can be found on multiple interfaces.
+    /// Addresses of the service. IPv4 or IPv6 addresses.
     pub addresses: HashSet<HostIp>,
 
     /// Properties of the service, decoded from TXT record.

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -1178,7 +1178,8 @@ pub struct ResolvedService {
 
     /// Addresses of the service.
     /// Each address maps to the list of interfaces on which the address is found.
-    /// The interface list is particularly useful for link-local IPv6 addresses.
+    /// The interface list is particularly useful for link-local IPv6 addresses,
+    /// where the same address can be found on multiple interfaces.
     pub addresses: HashMap<IpAddr, Vec<InterfaceId>>,
 
     /// Properties of the service, decoded from TXT record.

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -1154,7 +1154,7 @@ pub(crate) fn split_sub_domain(domain: &str) -> (&str, Option<&str>) {
 
 /// Represents a resolved service as a plain data struct.
 /// This is from a client (i.e. querier) point of view.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct ResolvedService {
     /// Service type and domain. For example, "_http._tcp.local."

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "logging")]
 use crate::log::debug;
 use crate::{
-    dns_parser::{DnsRecordBox, DnsRecordExt, DnsSrv, InterfaceId, RRType},
+    dns_parser::{DnsRecordBox, DnsRecordExt, DnsSrv, HostIp, RRType},
     Error, Result,
 };
 use if_addrs::{IfAddr, Interface};
@@ -372,11 +372,7 @@ impl ServiceInfo {
 
     /// Consumes self and returns a resolved service, i.e. a lite version of `ServiceInfo`.
     pub fn as_resolved_service(self) -> ResolvedService {
-        let addresses: HashMap<IpAddr, Vec<InterfaceId>> = self
-            .addresses
-            .into_iter()
-            .map(|a| (a, Vec::new()))
-            .collect();
+        let addresses: HashSet<HostIp> = self.addresses.into_iter().map(|a| a.into()).collect();
         ResolvedService {
             ty_domain: self.ty_domain,
             sub_ty_domain: self.sub_domain,
@@ -1180,7 +1176,7 @@ pub struct ResolvedService {
     /// Each address maps to the list of interfaces on which the address is found.
     /// The interface list is particularly useful for link-local IPv6 addresses,
     /// where the same address can be found on multiple interfaces.
-    pub addresses: HashMap<IpAddr, Vec<InterfaceId>>,
+    pub addresses: HashSet<HostIp>,
 
     /// Properties of the service, decoded from TXT record.
     pub txt_properties: TxtProperties,

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -2635,10 +2635,10 @@ fn test_use_service_detailed_v6() {
                     resolved.addresses.len() > 0,
                     "Should have at least one address"
                 );
-                let first_addr = resolved.addresses.into_iter().next().unwrap();
+                let (first_addr, interfaces) = resolved.addresses.into_iter().next().unwrap();
                 assert!(first_addr.is_ipv6(), "Address should be IPv6");
-                let interface_id = first_addr.scope();
-                println!("Resolved address: {:?}", first_addr.ip());
+                let interface_id = interfaces.get(0).unwrap();
+                println!("Resolved address: {:?}", first_addr);
                 println!(
                     "Interface ID of the first addr: {} index: {}",
                     interface_id.name(),

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -2641,8 +2641,7 @@ fn test_use_service_detailed_v6() {
                 println!("Resolved address: {:?}", first_addr);
                 println!(
                     "Interface ID of the first addr: {} index: {}",
-                    interface_id.name(),
-                    interface_id.index()
+                    interface_id.name, interface_id.index
                 );
                 break;
             }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -380,7 +380,7 @@ fn service_without_properties_with_alter_net_v6() {
                     );
                     // match only our service and not v4 one
                     if fullname.as_str() == info.get_fullname() {
-                        let addrs: Vec<&IpAddr> = info
+                        let addrs: Vec<_> = info
                             .get_addresses()
                             .iter()
                             .filter(|a| a.is_ipv6())
@@ -2461,4 +2461,207 @@ fn timed_println(msg: String) {
     let now = SystemTime::now();
     let formatted_time = humantime::format_rfc3339(now);
     println!("[{}] {}", formatted_time, msg);
+}
+
+#[test]
+fn test_use_service_detailed() {
+    // start a server
+    let ty_domain = "_svc-detailed._udp.local.";
+    let host_name = "service_detailed.local.";
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap();
+    let instance_name = now.as_micros().to_string(); // Create a unique name.
+    let port = 5200;
+
+    // Get a single IPv4 address
+    let ip_addr1 = my_ip_interfaces()
+        .iter()
+        .find(|iface| iface.ip().is_ipv4())
+        .map(|iface| iface.ip())
+        .unwrap();
+
+    // Register the service.
+    let service1 = ServiceInfo::new(ty_domain, &instance_name, host_name, &ip_addr1, port, None)
+        .expect("valid service info");
+    let server1 = ServiceDaemon::new().expect("failed to start server");
+    server1
+        .register(service1)
+        .expect("Failed to register service1");
+
+    // wait for the service announced.
+    sleep(Duration::from_secs(1));
+
+    // start a client
+    let client = ServiceDaemon::new().expect("failed to start client");
+    let receiver = client.browse(ty_domain).unwrap();
+    let timeout = Duration::from_secs(2);
+    let mut got_resolved = false;
+    let mut got_detailed = false;
+
+    while let Ok(event) = receiver.recv_timeout(timeout) {
+        match event {
+            ServiceEvent::ServiceResolved(_) => {
+                got_resolved = true;
+                break;
+            }
+            ServiceEvent::ServiceDetailed(_) => {
+                got_detailed = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    assert!(
+        got_resolved,
+        "Should receive ServiceResolved event by default"
+    );
+    assert!(
+        !got_detailed,
+        "Should not receive ServiceDetailed event by default"
+    );
+
+    // Now enable use_resolved_service and test for ServiceDetailed
+    client.use_service_detailed(true).unwrap();
+    let browse_chan = client.browse(ty_domain).unwrap();
+    let mut got_detailed = false;
+    let mut got_resolved = false;
+
+    while let Ok(event) = browse_chan.recv_timeout(timeout) {
+        match event {
+            ServiceEvent::ServiceDetailed(resolved) => {
+                got_detailed = true;
+                println!("Scoped address: {:?}", resolved.addresses);
+                break;
+            }
+            ServiceEvent::ServiceResolved(_) => {
+                got_resolved = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+    assert!(
+        got_detailed,
+        "Should receive ServiceDetailed event when enabled"
+    );
+    assert!(
+        !got_resolved,
+        "Should not receive ServiceResolved event when detailed is enabled"
+    );
+
+    server1.shutdown().unwrap();
+    client.shutdown().unwrap();
+}
+
+#[test]
+fn test_use_service_detailed_v6() {
+    // start a server
+    let ty_domain = "_detailed-v6._udp.local.";
+    let host_name = "service_detailed_v6.local.";
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap();
+    let instance_name = now.as_micros().to_string(); // Create a unique name.
+    let port = 5200;
+
+    // Get a single IPv4 address
+    let ipv6_addrs: Vec<_> = my_ip_interfaces()
+        .iter()
+        .filter(|iface| iface.ip().is_ipv6() && iface.is_link_local())
+        .map(|iface| iface.ip())
+        .collect();
+
+    // Register the service.
+    let service1 = ServiceInfo::new(
+        ty_domain,
+        &instance_name,
+        host_name,
+        &ipv6_addrs[..],
+        port,
+        None,
+    )
+    .expect("valid service info");
+    let server1 = ServiceDaemon::new().expect("failed to start server");
+    server1
+        .register(service1)
+        .expect("Failed to register service1");
+
+    // wait for the service announced.
+    sleep(Duration::from_secs(1));
+
+    // start a client
+    let client = ServiceDaemon::new().expect("failed to start client");
+    let receiver = client.browse(ty_domain).unwrap();
+    let timeout = Duration::from_secs(2);
+    let mut got_resolved = false;
+    let mut got_detailed = false;
+
+    while let Ok(event) = receiver.recv_timeout(timeout) {
+        match event {
+            ServiceEvent::ServiceResolved(_) => {
+                got_resolved = true;
+                break;
+            }
+            ServiceEvent::ServiceDetailed(_) => {
+                got_detailed = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    assert!(
+        got_resolved,
+        "Should receive ServiceResolved event by default"
+    );
+    assert!(
+        !got_detailed,
+        "Should not receive ServiceDetailed event by default"
+    );
+
+    // Now enable use_resolved_service and test for ServiceDetailed
+    client.use_service_detailed(true).unwrap();
+    let browse_chan = client.browse(ty_domain).unwrap();
+    let mut got_detailed = false;
+    let mut got_resolved = false;
+
+    while let Ok(event) = browse_chan.recv_timeout(timeout) {
+        match event {
+            ServiceEvent::ServiceDetailed(resolved) => {
+                got_detailed = true;
+                assert!(
+                    resolved.addresses.len() > 0,
+                    "Should have at least one address"
+                );
+                let first_addr = resolved.addresses.into_iter().next().unwrap();
+                assert!(first_addr.is_ipv6(), "Address should be IPv6");
+                let interface_id = first_addr.scope();
+                println!("Resolved address: {:?}", first_addr.ip());
+                println!(
+                    "Interface ID of the first addr: {} index: {}",
+                    interface_id.name(),
+                    interface_id.index()
+                );
+                break;
+            }
+            ServiceEvent::ServiceResolved(_) => {
+                got_resolved = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+    assert!(
+        got_detailed,
+        "Should receive ServiceDetailed event when enabled"
+    );
+    assert!(
+        !got_resolved,
+        "Should not receive ServiceResolved event when detailed is enabled"
+    );
+
+    server1.shutdown().unwrap();
+    client.shutdown().unwrap();
 }


### PR DESCRIPTION
This is to address issue #358.  The basic approach is: 

- Keep it backward compatible for `ServiceEvent::ServiceResolved` event, which returns `ServiceInfo`.
- Introduce a new event `ServiceEvent::ServiceDetailed` to return `ResolvedService`.  Update `ResolvedService.addresses` to be `HashSet<HostIp>`, where `HostIp` is a wrapper of `IpAddr` that includes `scope_id` for IPv6 addresses.

To opt in to receive `ServiceEvent::ServiceDetailed` instead of `ServiceEvent::ServiceResolved`, the user would call `ServiceDaemon::use_service_detailed(true)` of its client daemon.

So, in short, to use IPv6 address with scope (interface id), one needs to use the new `ServiceDetailed` event and `ResolvedService` struct instead of `ServiceInfo`.   In the long term, I hope to deprecate the uses of `ServiceInfo` on the client (querier) side.

Also note, `HostnameResolutionEvent` is also updated to use `HostIp` instead of `IpAddr`.  I think it's better to make this breaking change at the same time.

