### PR TITLE
bump up version to 0.13.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 0.13.11 (2025-7-7)
+
+This is a small bugfix release before we add potential breaking changes.
+
+* `8b221d2 2025-06-22` derive `Clone` for `ServiceEvent` and `HostnameResolutionEvent` (#366) (Shadowcat650)
+
+Welcome our new contributor @Shadowcat650 !
+
 # Version 0.13.10 (2025-6-21)
 
 This is a bugfix release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdns-sd"
-version = "0.13.10"
+version = "0.13.11"
 authors = ["keepsimple <keepsimple@gmail.com>"]
 edition = "2018"
 rust-version = "1.70.0"


### PR DESCRIPTION
I wanted to get the current code released before potential breaking changes.