### PR TITLE
Exclude interfaces that are operational down

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = ["async", "logging"]
 [dependencies]
 fastrand = "2.3"
 flume = { version = "0.11", default-features = false } # channel between threads
-if-addrs = { version = "0.13", features = ["link-local"] } # get local IP addresses
+if-addrs = { version = "0.14", features = ["link-local"] } # get local IP addresses
 log = { version = "0.4", optional = true }             # logging
 mio = { version = "1.0", features = ["os-poll", "net"] }  # select/poll sockets
 socket2 = { version = "0.5.8", features = ["all"] }      # socket APIs

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -34,7 +34,7 @@ pub struct InterfaceId {
 
 impl fmt::Display for InterfaceId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}(idx {})", self.name, self.index)
+        write!(f, "{}('{}')", self.index, self.name)
     }
 }
 
@@ -53,11 +53,30 @@ pub struct HostIpV4 {
     addr: Ipv4Addr,
 }
 
+impl HostIpV4 {
+    /// Returns the IPv4 address.
+    pub const fn addr(&self) -> &Ipv4Addr {
+        &self.addr
+    }
+}
+
 /// An IPv6 address with scope_id (interface identifier).
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct HostIpV6 {
     addr: Ipv6Addr,
     scope_id: InterfaceId,
+}
+
+impl HostIpV6 {
+    /// Returns the IPv6 address.
+    pub const fn addr(&self) -> &Ipv6Addr {
+        &self.addr
+    }
+
+    /// Returns the scope_id for this IPv6 address.
+    pub const fn scope_id(&self) -> &InterfaceId {
+        &self.scope_id
+    }
 }
 
 /// A host IP address, either IPv4 or IPv6, that supports scope_id for IPv6.

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -3391,12 +3391,12 @@ fn call_hostname_resolution_listener(
 }
 
 /// Returns valid network interfaces in the host system.
-/// Loopback interfaces are excluded.
+/// Loopback interfaces are excluded. Operational down interfaces are excluded as well.
 fn my_ip_interfaces(with_loopback: bool) -> Vec<Interface> {
     if_addrs::get_if_addrs()
         .unwrap_or_default()
         .into_iter()
-        .filter(|i| !i.is_loopback() || with_loopback)
+        .filter(|i| i.is_oper_up() && (!i.is_loopback() || with_loopback))
         .collect()
 }
 

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -1375,6 +1375,7 @@ mod tests {
             name: "e0".to_string(),
             addr: ipv4_intf_addr,
             index: Some(1),
+            oper_status: if_addrs::IfOperStatus::Up,
             #[cfg(windows)]
             adapter_name: "ethernet".to_string(),
         };
@@ -1401,6 +1402,7 @@ mod tests {
             name: "eth0".to_string(),
             addr: ipv6_intf_addr,
             index: Some(2),
+            oper_status: if_addrs::IfOperStatus::Up,
             #[cfg(windows)]
             adapter_name: "ethernet".to_string(),
         };

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -2648,10 +2648,6 @@ fn test_use_service_detailed_v6() {
                     assert!(false, "Address should be IPv6");
                     return;
                 };
-                assert!(
-                    ip_v6.addr().is_unicast_link_local(),
-                    "Address should be link-local"
-                );
                 let scope_id = ip_v6.scope_id();
                 assert!(
                     scope_id.index != 0,

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -2532,7 +2532,13 @@ fn test_use_service_detailed() {
         match event {
             ServiceEvent::ServiceDetailed(resolved) => {
                 got_detailed = true;
-                println!("Scoped address: {:?}", resolved.addresses);
+                println!("address: {:?}", resolved.addresses);
+                let first_addr = resolved.addresses.iter().next().unwrap();
+                let HostIp::V4(ip_v4) = first_addr else {
+                    assert!(false, "Address should be IPv4");
+                    return;
+                };
+                println!("Resolved address: {}", ip_v4.addr());
                 break;
             }
             ServiceEvent::ServiceResolved(_) => {
@@ -2638,6 +2644,20 @@ fn test_use_service_detailed_v6() {
                 let first_addr = resolved.addresses.into_iter().next().unwrap();
                 assert!(first_addr.is_ipv6(), "Address should be IPv6");
                 println!("Resolved address: {}", first_addr);
+                let HostIp::V6(ip_v6) = first_addr else {
+                    assert!(false, "Address should be IPv6");
+                    return;
+                };
+                assert!(
+                    ip_v6.addr().is_unicast_link_local(),
+                    "Address should be link-local"
+                );
+                let scope_id = ip_v6.scope_id();
+                assert!(
+                    scope_id.index != 0,
+                    "Link-local address should have a scope ID"
+                );
+                println!("Scope ID: {}", scope_id);
                 break;
             }
             ServiceEvent::ServiceResolved(_) => {


### PR DESCRIPTION
This is a follow-up patch to address issue #358 and #368 .

Also added access methods for `HostIpV4` and `HostIpV6`.