### PR TITLE
ServiceEvent: add non_exhaustive and fix clippy

### DIFF
--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -486,7 +486,7 @@ impl DnsCache {
 
     /// Returns a tuple of:
     /// 1. the map of instance names together with RRType(s) that are due for refresh
-    ///     its SRV or TXT records.
+    ///    its SRV or TXT records.
     /// 2. the set of new timers that are due for refresh.
     pub(crate) fn refresh_due_srv_txt(
         &mut self,

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -1125,7 +1125,7 @@ impl fmt::Debug for TxtProperty {
             |v| {
                 std::str::from_utf8(&v[..]).map_or_else(
                     |_| format!("Some({})", u8_slice_to_hex(&v[..])),
-                    |s| format!("Some(\"{}\")", s),
+                    |s| format!("Some(\"{s}\")"),
                 )
             },
         );
@@ -1983,8 +1983,7 @@ impl DnsIncoming {
 
             let Some(rr_type) = RRType::from_u16(ty) else {
                 return Err(Error::Msg(format!(
-                    "DNS incoming: question idx {} qtype unknown: {}",
-                    i, ty
+                    "DNS incoming: question idx {i} qtype unknown: {ty}",
                 )));
             };
 
@@ -2209,16 +2208,14 @@ impl DnsIncoming {
         self.offset += 1;
         if block_num != 0 {
             return Err(Error::Msg(format!(
-                "NSEC block number is not 0: {}",
-                block_num
+                "NSEC block number is not 0: {block_num}"
             )));
         }
 
         let block_len = self.data[self.offset] as usize;
         if !(1..=32).contains(&block_len) {
             return Err(Error::Msg(format!(
-                "NSEC block length must be in the range 1-32: {}",
-                block_len
+                "NSEC block length must be in the range 1-32: {block_len}"
             )));
         }
         self.offset += 1;
@@ -2343,7 +2340,7 @@ impl DnsIncoming {
                     }
 
                     name += str::from_utf8(&data[offset..ending])
-                        .map_err(|e| Error::Msg(format!("read_name: from_utf8: {}", e)))?;
+                        .map_err(|e| Error::Msg(format!("read_name: from_utf8: {e}")))?;
                     name += ".";
                     offset += length as usize;
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,8 +17,8 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Msg(s) => write!(f, "{}", s),
-            Self::ParseIpAddr(s) => write!(f, "parsing of ip addr failed, reason: {}", s),
+            Self::Msg(s) => write!(f, "{s}"),
+            Self::ParseIpAddr(s) => write!(f, "parsing of ip addr failed, reason: {s}"),
             Self::Again => write!(f, "try again"),
         }
     }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -437,8 +437,7 @@ impl ServiceDaemon {
 
         if len_max > SERVICE_NAME_LEN_MAX_LIMIT {
             return Err(Error::Msg(format!(
-                "service name length max {} is too large",
-                len_max
+                "service name length max {len_max} is too large"
             )));
         }
 
@@ -3341,6 +3340,7 @@ fn add_answer_of_service(
 /// All possible events sent to the client from the daemon
 /// regarding service discovery.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum ServiceEvent {
     /// Started searching for a service type.
     SearchStarted(String),
@@ -3903,7 +3903,7 @@ fn name_change(original: &str) -> String {
         return format!("{original} (2)");
     };
 
-    let mut new_name = format!("{} (2)", first_part);
+    let mut new_name = format!("{first_part} (2)");
 
     // check if there is already has `(<num>)` suffix.
     if let Some(paren_pos) = first_part.rfind(" (") {
@@ -3939,7 +3939,7 @@ fn hostname_change(original: &str) -> String {
         return format!("{original}-2");
     };
 
-    let mut new_name = format!("{}-2", first_part);
+    let mut new_name = format!("{first_part}-2");
 
     // check if there is already a `-<num>` suffix
     if let Some(hyphen_pos) = first_part.rfind('-') {

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -101,7 +101,7 @@ impl ServiceInfo {
     ) -> Result<Self> {
         let (ty_domain, sub_domain) = split_sub_domain(ty_domain);
 
-        let fullname = format!("{}.{}", my_name, ty_domain);
+        let fullname = format!("{my_name}.{ty_domain}");
         let ty_domain = ty_domain.to_string();
         let sub_domain = sub_domain.map(str::to_string);
         let server = normalize_hostname(host_name.to_string());
@@ -651,7 +651,7 @@ impl fmt::Debug for TxtProperty {
             |v| {
                 std::str::from_utf8(&v[..]).map_or_else(
                     |_| format!("Some({})", u8_slice_to_hex(&v[..])),
-                    |s| format!("Some(\"{}\")", s),
+                    |s| format!("Some(\"{s}\")"),
                 )
             },
         );


### PR DESCRIPTION
As we recently added `ServiceEvent::ServiceDetailed`, it will be a breaking change in the next release. I think it's a good time to add `#[non_exhaustive]` as well.

Also fixed clippy warnings generated by the latest Rust 1.88.0