### PR TITLE
refactoring: define our own interface struct to allow multiple addresses

### DIFF
--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -6,10 +6,9 @@
 use crate::log::{debug, trace};
 use crate::{
     dns_parser::{DnsAddress, DnsPointer, DnsRecordBox, DnsSrv, InterfaceId, RRType},
-    service_info::{split_sub_domain, valid_ip_on_intf, valid_two_addrs_on_intf},
+    service_info::{split_sub_domain, MyIntf},
     HostIp,
 };
-use if_addrs::Interface;
 use std::{
     collections::{HashMap, HashSet},
     time::SystemTime,
@@ -196,7 +195,7 @@ impl DnsCache {
     /// If you need to add new timers for related records, push into `timers`.
     pub(crate) fn add_or_update(
         &mut self,
-        intf: &Interface,
+        intf: &MyIntf,
         incoming: DnsRecordBox,
         timers: &mut Vec<u64>,
         is_for_us: bool,
@@ -260,11 +259,7 @@ impl DnsCache {
                     if rtype == RRType::A || rtype == RRType::AAAA {
                         if let Some(addr) = r.record.any().downcast_ref::<DnsAddress>() {
                             if let Some(addr_b) = incoming.any().downcast_ref::<DnsAddress>() {
-                                should_flush = valid_two_addrs_on_intf(
-                                    &addr.address().to_ip_addr(),
-                                    &addr_b.address().to_ip_addr(),
-                                    intf,
-                                );
+                                should_flush = addr.interface_id.index == addr_b.interface_id.index;
                             }
                         }
                     }
@@ -678,7 +673,7 @@ impl DnsCache {
             .collect()
     }
 
-    pub(crate) fn remove_addrs_on_disabled_intf(&mut self, disabled_intf: &Interface) {
+    pub(crate) fn remove_addrs_on_disabled_intf(&mut self, disabled_if_index: u32) {
         for (host, records) in self.addr.iter_mut() {
             records.retain(|record| {
                 let Some(dns_addr) = record.record.any().downcast_ref::<DnsAddress>() else {
@@ -686,10 +681,10 @@ impl DnsCache {
                 };
 
                 // Remove the record if it is on this interface.
-                if valid_ip_on_intf(&dns_addr.address().to_ip_addr(), disabled_intf) {
+                if dns_addr.interface_id.index == disabled_if_index {
                     debug!(
                         "removing ADDR on disabled intf: {:?} host {host}",
-                        dns_addr.address()
+                        dns_addr.interface_id.name
                     );
                     false
                 } else {

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -134,7 +134,7 @@ impl fmt::Display for HostIp {
             HostIp::V4(v4) => write!(f, "{}", v4.addr),
             HostIp::V6(v6) => {
                 if v6.scope_id.index != 0 {
-                    write!(f, "{}%{}", v6.addr, v6.scope_id.index)
+                    write!(f, "{}%{}", v6.addr, v6.scope_id.name)
                 } else {
                     write!(f, "{}", v6.addr)
                 }
@@ -623,10 +623,10 @@ pub trait DnsRecordExt: fmt::Debug {
 
 /// Resource Record for IPv4 address or IPv6 address.
 #[derive(Debug, Clone)]
-pub struct DnsAddress {
+pub(crate) struct DnsAddress {
     pub(crate) record: DnsRecord,
     address: IpAddr,
-    interface_id: InterfaceId,
+    pub(crate) interface_id: InterfaceId,
 }
 
 impl DnsAddress {

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -134,7 +134,14 @@ impl fmt::Display for HostIp {
             HostIp::V4(v4) => write!(f, "{}", v4.addr),
             HostIp::V6(v6) => {
                 if v6.scope_id.index != 0 {
-                    write!(f, "{}%{}", v6.addr, v6.scope_id.name)
+                    #[cfg(windows)]
+                    {
+                        write!(f, "{}%{}", v6.addr, v6.scope_id.index)
+                    }
+                    #[cfg(not(windows))]
+                    {
+                        write!(f, "{}%{}", v6.addr, v6.scope_id.name)
+                    }
                 } else {
                     write!(f, "{}", v6.addr)
                 }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -868,7 +868,7 @@ struct Zeroconf {
 }
 
 /// Join the multicast group for the given interface.
-fn socket_config(my_sock: &PktInfoUdpSocket, intf: &Interface) -> Result<()> {
+fn join_multicast_group(my_sock: &PktInfoUdpSocket, intf: &Interface) -> Result<()> {
     let intf_ip = &intf.ip();
     match intf_ip {
         IpAddr::V4(ip) => {
@@ -941,7 +941,7 @@ impl Zeroconf {
                 &ipv6_sock
             };
 
-            if let Err(e) = socket_config(&sock.pktinfo, &intf) {
+            if let Err(e) = join_multicast_group(&sock.pktinfo, &intf) {
                 debug!(
                     "config socket to join multicast: {}: {e}. Skipped.",
                     &intf.ip()
@@ -950,7 +950,7 @@ impl Zeroconf {
 
             let if_index = intf.index.unwrap_or(0);
 
-            // Add a DnsRegistry for this interface if not already present.
+            // Add this interface address if not already present.
             dns_registry_map
                 .entry(if_index)
                 .or_insert_with(DnsRegistry::new);
@@ -1541,7 +1541,7 @@ impl Zeroconf {
                 // If intf has a new address, add it to the existing interface.
                 let my_intf = entry.get_mut();
                 if !my_intf.addrs.contains(&intf.addr) {
-                    if let Err(e) = socket_config(&sock.pktinfo, &intf) {
+                    if let Err(e) = join_multicast_group(&sock.pktinfo, &intf) {
                         debug!("add_interface: socket_config {}: {e}", &intf.name);
                     }
                     my_intf.addrs.insert(intf.addr.clone());
@@ -1549,7 +1549,7 @@ impl Zeroconf {
                 }
             }
             Entry::Vacant(entry) => {
-                if let Err(e) = socket_config(&sock.pktinfo, &intf) {
+                if let Err(e) = join_multicast_group(&sock.pktinfo, &intf) {
                     debug!("add_interface: socket_config {}: {e}. Skipped.", &intf.name);
                     return;
                 }

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -4,9 +4,9 @@
 use crate::log::debug;
 use crate::{
     dns_parser::{DnsRecordBox, DnsRecordExt, DnsSrv, HostIp, RRType},
-    Error, Result,
+    Error, InterfaceId, Result,
 };
-use if_addrs::{IfAddr, Interface};
+use if_addrs::IfAddr;
 use std::{
     cmp,
     collections::{HashMap, HashSet},
@@ -19,6 +19,32 @@ use std::{
 /// Default TTL values in seconds
 const DNS_HOST_TTL: u32 = 120; // 2 minutes for host records (A, SRV etc) per RFC6762
 const DNS_OTHER_TTL: u32 = 4500; // 75 minutes for non-host records (PTR, TXT etc) per RFC6762
+
+#[derive(Debug)]
+pub(crate) struct MyIntf {
+    pub(crate) name: String,
+    pub(crate) index: u32,
+    pub(crate) addrs: HashSet<IfAddr>,
+}
+
+impl MyIntf {
+    pub(crate) fn next_ifaddr_v4(&self) -> Option<&IfAddr> {
+        self.addrs.iter().find(|a| a.ip().is_ipv4())
+    }
+
+    pub(crate) fn next_ifaddr_v6(&self) -> Option<&IfAddr> {
+        self.addrs.iter().find(|a| a.ip().is_ipv6())
+    }
+}
+
+impl From<&MyIntf> for InterfaceId {
+    fn from(my_intf: &MyIntf) -> Self {
+        InterfaceId {
+            name: my_intf.name.clone(),
+            index: my_intf.index,
+        }
+    }
+}
 
 /// Complete info about a Service Instance.
 ///
@@ -43,7 +69,7 @@ pub struct ServiceInfo {
     txt_properties: TxtProperties,
     addr_auto: bool, // Let the system update addresses automatically.
 
-    status: HashMap<Interface, ServiceStatus>,
+    status: HashMap<u32, ServiceStatus>, // keyed by interface index.
 
     /// Whether we need to probe names before announcing this service.
     requires_probe: bool,
@@ -286,12 +312,19 @@ impl ServiceInfo {
         self.weight
     }
 
-    /// Returns a list of addresses that are in the same LAN as
-    /// the interface `intf`.
-    pub(crate) fn get_addrs_on_intf(&self, intf: &Interface) -> Vec<IpAddr> {
+    /// Returns all addresses published
+    pub(crate) fn get_addrs_on_my_intf_v4(&self, my_intf: &MyIntf) -> Vec<IpAddr> {
         self.addresses
             .iter()
-            .filter(|a| valid_ip_on_intf(a, intf))
+            .filter(|a| a.is_ipv4() && my_intf.addrs.iter().any(|x| valid_ip_on_intf(a, x)))
+            .copied()
+            .collect()
+    }
+
+    pub(crate) fn get_addrs_on_my_intf_v6(&self, my_intf: &MyIntf) -> Vec<IpAddr> {
+        self.addresses
+            .iter()
+            .filter(|a| a.is_ipv6() && my_intf.addrs.iter().any(|x| valid_ip_on_intf(a, x)))
             .copied()
             .collect()
     }
@@ -352,20 +385,20 @@ impl ServiceInfo {
         self.other_ttl = ttl;
     }
 
-    pub(crate) fn set_status(&mut self, intf: &Interface, status: ServiceStatus) {
-        match self.status.get_mut(intf) {
+    pub(crate) fn set_status(&mut self, if_index: u32, status: ServiceStatus) {
+        match self.status.get_mut(&if_index) {
             Some(service_status) => {
                 *service_status = status;
             }
             None => {
-                self.status.entry(intf.clone()).or_insert(status);
+                self.status.entry(if_index).or_insert(status);
             }
         }
     }
 
-    pub(crate) fn get_status(&self, intf: &Interface) -> ServiceStatus {
+    pub(crate) fn get_status(&self, intf: u32) -> ServiceStatus {
         self.status
-            .get(intf)
+            .get(&intf)
             .cloned()
             .unwrap_or(ServiceStatus::Unknown)
     }
@@ -826,40 +859,19 @@ fn decode_txt_unique(txt: &[u8]) -> Vec<TxtProperty> {
 }
 
 /// Returns true if `addr` is in the same network of `intf`.
-pub(crate) fn valid_ip_on_intf(addr: &IpAddr, intf: &Interface) -> bool {
-    match (addr, &intf.addr) {
-        (IpAddr::V4(addr), IfAddr::V4(intf)) => {
-            let netmask = u32::from(intf.netmask);
-            let intf_net = u32::from(intf.ip) & netmask;
+pub(crate) fn valid_ip_on_intf(addr: &IpAddr, if_addr: &IfAddr) -> bool {
+    match (addr, if_addr) {
+        (IpAddr::V4(addr), IfAddr::V4(if_v4)) => {
+            let netmask = u32::from(if_v4.netmask);
+            let intf_net = u32::from(if_v4.ip) & netmask;
             let addr_net = u32::from(*addr) & netmask;
             addr_net == intf_net
         }
-        (IpAddr::V6(addr), IfAddr::V6(intf)) => {
-            let netmask = u128::from(intf.netmask);
-            let intf_net = u128::from(intf.ip) & netmask;
+        (IpAddr::V6(addr), IfAddr::V6(if_v6)) => {
+            let netmask = u128::from(if_v6.netmask);
+            let intf_net = u128::from(if_v6.ip) & netmask;
             let addr_net = u128::from(*addr) & netmask;
             addr_net == intf_net
-        }
-        _ => false,
-    }
-}
-
-/// Returns true if `addr_a` and `addr_b` are in the same network as `intf`.
-pub fn valid_two_addrs_on_intf(addr_a: &IpAddr, addr_b: &IpAddr, intf: &Interface) -> bool {
-    match (addr_a, addr_b, &intf.addr) {
-        (IpAddr::V4(ipv4_a), IpAddr::V4(ipv4_b), IfAddr::V4(intf)) => {
-            let netmask = u32::from(intf.netmask);
-            let intf_net = u32::from(intf.ip) & netmask;
-            let net_a = u32::from(*ipv4_a) & netmask;
-            let net_b = u32::from(*ipv4_b) & netmask;
-            net_a == intf_net && net_b == intf_net
-        }
-        (IpAddr::V6(ipv6_a), IpAddr::V6(ipv6_b), IfAddr::V6(intf)) => {
-            let netmask = u128::from(intf.netmask);
-            let intf_net = u128::from(intf.ip) & netmask;
-            let net_a = u128::from(*ipv6_a) & netmask;
-            let net_b = u128::from(*ipv6_b) & netmask;
-            net_a == intf_net && net_b == intf_net
         }
         _ => false,
     }
@@ -1192,11 +1204,7 @@ impl ResolvedService {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        decode_txt, encode_txt, u8_slice_to_hex, valid_two_addrs_on_intf, ServiceInfo, TxtProperty,
-    };
-    use if_addrs::{IfAddr, Ifv4Addr, Ifv6Addr, Interface};
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use super::{decode_txt, encode_txt, u8_slice_to_hex, ServiceInfo, TxtProperty};
 
     #[test]
     fn test_txt_encode_decode() {
@@ -1358,62 +1366,5 @@ mod tests {
         assert_eq!(decoded.len(), 1);
         // Test that the key of the property we parsed is "key1"
         assert_eq!(decoded[0].key, "key1");
-    }
-
-    #[test]
-    fn test_valid_two_addrs_on_intf() {
-        // test IPv4
-
-        let ipv4_netmask = Ipv4Addr::new(192, 168, 1, 0);
-        let ipv4_intf_addr = IfAddr::V4(Ifv4Addr {
-            ip: Ipv4Addr::new(192, 168, 1, 10),
-            netmask: ipv4_netmask,
-            prefixlen: 24,
-            broadcast: None,
-        });
-        let ipv4_intf = Interface {
-            name: "e0".to_string(),
-            addr: ipv4_intf_addr,
-            index: Some(1),
-            oper_status: if_addrs::IfOperStatus::Up,
-            #[cfg(windows)]
-            adapter_name: "ethernet".to_string(),
-        };
-        let ipv4_a = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10));
-        let ipv4_b = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 11));
-
-        let result = valid_two_addrs_on_intf(&ipv4_a, &ipv4_b, &ipv4_intf);
-        assert!(result);
-
-        let ipv4_c = IpAddr::V4(Ipv4Addr::new(172, 17, 0, 1));
-        let result = valid_two_addrs_on_intf(&ipv4_a, &ipv4_c, &ipv4_intf);
-        assert!(!result);
-
-        // test IPv6 (generated by AI)
-
-        let ipv6_netmask = Ipv6Addr::new(0xffff, 0xffff, 0, 0, 0, 0, 0, 0); // Equivalent to /32 prefix length
-        let ipv6_intf_addr = IfAddr::V6(Ifv6Addr {
-            ip: Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1),
-            netmask: ipv6_netmask,
-            prefixlen: 32,
-            broadcast: None,
-        });
-        let ipv6_intf = Interface {
-            name: "eth0".to_string(),
-            addr: ipv6_intf_addr,
-            index: Some(2),
-            oper_status: if_addrs::IfOperStatus::Up,
-            #[cfg(windows)]
-            adapter_name: "ethernet".to_string(),
-        };
-        let ipv6_a = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
-        let ipv6_b = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 2));
-
-        let result = valid_two_addrs_on_intf(&ipv6_a, &ipv6_b, &ipv6_intf);
-        assert!(result); // Expect true since both addresses are in the same subnet
-
-        let ipv6_c = IpAddr::V6(Ipv6Addr::new(0x2002, 0xdb8, 0, 0, 0, 0, 0, 1));
-        let result = valid_two_addrs_on_intf(&ipv6_a, &ipv6_c, &ipv6_intf);
-        assert!(!result); // Expect false since addresses are in different subnets
     }
 }

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -20,10 +20,16 @@ use std::{
 const DNS_HOST_TTL: u32 = 120; // 2 minutes for host records (A, SRV etc) per RFC6762
 const DNS_OTHER_TTL: u32 = 4500; // 75 minutes for non-host records (PTR, TXT etc) per RFC6762
 
+/// Represents a network interface.
 #[derive(Debug)]
 pub(crate) struct MyIntf {
+    /// The name of the interface.
     pub(crate) name: String,
+
+    /// Unique index assigned by the OS. Used by IPv6 for its scope_id.
     pub(crate) index: u32,
+
+    /// One interface can have multiple IPv4 addresses and/or multiple IPv6 addresses.
     pub(crate) addrs: HashSet<IfAddr>,
 }
 


### PR DESCRIPTION
This is triggered by #377 as currently we would skip 2nd IP address on an interface due to `join_multicast_group` error on the same interface.   Strictly speaking, this is wrong and it can cause confusion in debugging as `addr 1` is in `ZeroConf.my_intfs` but `addr 2` (on the same interface) is not. 

Also, currently we directly use `Interface` from `if-addrs` crate, but it is per address, not truly per interface. I took this opportunity to define a new interface struct for us `MyIntf` that represents a network interface that supports multiple addresses.

The diff is very extensive but conceptually really just `Interface` is replaced by `MyIntf`. 
