### PR TITLE
rename ServiceDetailed to ServiceData

### DIFF
--- a/examples/query.rs
+++ b/examples/query.rs
@@ -38,7 +38,7 @@ fn main() {
     let now = std::time::Instant::now();
     while let Ok(event) = receiver.recv() {
         match event {
-            ServiceEvent::ServiceDetailed(info) => {
+            ServiceEvent::ServiceData(info) => {
                 println!(
                     "At {:?}: Resolved a new service: {}\n host: {}\n port: {}",
                     now.elapsed(),

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -30,7 +30,7 @@ fn main() {
     // Create a daemon
     let mdns = ServiceDaemon::new().expect("Failed to create daemon");
     mdns.use_service_data(true)
-        .expect("Failed to use service detailed");
+        .expect("Failed to use ServiceData");
 
     // Browse for the service type
     let receiver = mdns.browse(&service_type).expect("Failed to browse");

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -29,7 +29,7 @@ fn main() {
 
     // Create a daemon
     let mdns = ServiceDaemon::new().expect("Failed to create daemon");
-    mdns.use_service_detailed(true)
+    mdns.use_service_data(true)
         .expect("Failed to use service detailed");
 
     // Browse for the service type

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -860,8 +860,8 @@ struct Zeroconf {
 
     multicast_loop_v6: bool,
 
-    /// Whether to use [ServiceEvent::ServiceDetailed] instead of [ServiceEvent::ServiceResolved].
-    use_service_detailed: bool,
+    /// Whether to use [ServiceEvent::ServiceData] instead of [ServiceEvent::ServiceResolved].
+    use_service_data: bool,
 
     #[cfg(test)]
     test_down_interfaces: HashSet<String>,
@@ -1011,7 +1011,7 @@ impl Zeroconf {
             resolved: HashSet::new(),
             multicast_loop_v4: true,
             multicast_loop_v6: true,
-            use_service_detailed: false,
+            use_service_data: false,
 
             #[cfg(test)]
             test_down_interfaces: HashSet::new(),
@@ -1196,7 +1196,7 @@ impl Zeroconf {
             DaemonOption::DisableInterface(if_kind) => self.disable_interface(if_kind),
             DaemonOption::MulticastLoopV4(on) => self.set_multicast_loop_v4(on),
             DaemonOption::MulticastLoopV6(on) => self.set_multicast_loop_v6(on),
-            DaemonOption::UseServiceData(on) => self.use_service_detailed = on,
+            DaemonOption::UseServiceData(on) => self.use_service_data = on,
             #[cfg(test)]
             DaemonOption::TestDownInterface(ifname) => {
                 self.test_down_interfaces.insert(ifname);
@@ -2032,7 +2032,7 @@ impl Zeroconf {
             for record in records.iter().filter(|r| !r.record.expires_soon(now)) {
                 if let Some(ptr) = record.record.any().downcast_ref::<DnsPointer>() {
                     let mut new_event = None;
-                    if self.use_service_detailed {
+                    if self.use_service_data {
                         match self.resolve_service_from_cache(ty_domain, ptr.alias()) {
                             Ok(resolved_service) => {
                                 if resolved_service.is_valid() {
@@ -2604,7 +2604,7 @@ impl Zeroconf {
                         let mut instance_found = false;
                         let mut new_event = None;
 
-                        if self.use_service_detailed {
+                        if self.use_service_data {
                             if let Ok(resolved) =
                                 self.resolve_service_from_cache(ty_domain, dns_ptr.alias())
                             {
@@ -3467,7 +3467,7 @@ pub enum ServiceEvent {
     ServiceResolved(ServiceInfo),
 
     /// Resolved a service instance in a ResolvedService struct.
-    /// Must call [ServiceDaemon::use_service_detailed] to receive this event.
+    /// Must call [ServiceDaemon::use_service_data] to receive this event.
     ServiceData(Box<ResolvedService>),
 
     /// A service instance (service_type, fullname) was removed.
@@ -4807,20 +4807,20 @@ mod tests {
         let receiver = client.browse(ty_domain).unwrap();
 
         let timeout = Duration::from_secs(3);
-        let mut got_detailed = false;
+        let mut got_data = false;
 
         while let Ok(event) = receiver.recv_timeout(timeout) {
             match event {
                 ServiceEvent::ServiceData(_) => {
-                    println!("Received ServiceDetailed event");
-                    got_detailed = true;
+                    println!("Received ServiceData event");
+                    got_data = true;
                     break;
                 }
                 _ => {}
             }
         }
 
-        assert!(got_detailed, "Should receive ServiceDetailed event");
+        assert!(got_data, "Should receive ServiceData event");
 
         // Set a short IP check interval to detect interface changes quickly.
         client.set_ip_check_interval(1).unwrap();
@@ -4845,20 +4845,20 @@ mod tests {
 
         println!("Bringing up interface {}", &intf_name);
         client.test_up_interface(&intf_name).unwrap();
-        let mut got_detailed = false;
+        let mut got_data = false;
         while let Ok(event) = receiver.recv_timeout(timeout) {
             match event {
                 ServiceEvent::ServiceData(resolved) => {
-                    got_detailed = true;
-                    println!("Received ServiceDetailed: {:?}", resolved);
+                    got_data = true;
+                    println!("Received ServiceData: {:?}", resolved);
                     break;
                 }
                 _ => {}
             }
         }
         assert!(
-            got_detailed,
-            "Should receive ServiceDetailed event after interface is back up"
+            got_data,
+            "Should receive ServiceData event after interface is back up"
         );
 
         server1.shutdown().unwrap();

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -2037,9 +2037,8 @@ impl Zeroconf {
                             Ok(resolved_service) => {
                                 if resolved_service.is_valid() {
                                     debug!("Resolved service from cache: {}", ptr.alias());
-                                    new_event = Some(ServiceEvent::ServiceDetailed(Box::new(
-                                        resolved_service,
-                                    )));
+                                    new_event =
+                                        Some(ServiceEvent::ServiceData(Box::new(resolved_service)));
                                 } else {
                                     debug!("Resolved service is not valid: {}", ptr.alias());
                                 }
@@ -2615,8 +2614,7 @@ impl Zeroconf {
                                 );
                                 instance_found = true;
                                 if resolved.is_valid() {
-                                    new_event =
-                                        Some(ServiceEvent::ServiceDetailed(Box::new(resolved)));
+                                    new_event = Some(ServiceEvent::ServiceData(Box::new(resolved)));
                                 } else {
                                     debug!("Resolved service is not valid: {}", dns_ptr.alias());
                                 }
@@ -3470,7 +3468,7 @@ pub enum ServiceEvent {
 
     /// Resolved a service instance in a ResolvedService struct.
     /// Must call [ServiceDaemon::use_service_detailed] to receive this event.
-    ServiceDetailed(Box<ResolvedService>),
+    ServiceData(Box<ResolvedService>),
 
     /// A service instance (service_type, fullname) was removed.
     ServiceRemoved(String, String),
@@ -4813,7 +4811,7 @@ mod tests {
 
         while let Ok(event) = receiver.recv_timeout(timeout) {
             match event {
-                ServiceEvent::ServiceDetailed(_) => {
+                ServiceEvent::ServiceData(_) => {
                     println!("Received ServiceDetailed event");
                     got_detailed = true;
                     break;
@@ -4850,7 +4848,7 @@ mod tests {
         let mut got_detailed = false;
         while let Ok(event) = receiver.recv_timeout(timeout) {
             match event {
-                ServiceEvent::ServiceDetailed(resolved) => {
+                ServiceEvent::ServiceData(resolved) => {
                     got_detailed = true;
                     println!("Received ServiceDetailed: {:?}", resolved);
                     break;

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -545,11 +545,11 @@ impl ServiceDaemon {
         self.send_cmd(Command::SetOption(DaemonOption::MulticastLoopV6(on)))
     }
 
-    /// Enable or disable the use of [ServiceEvent::ServiceDetailed] instead of [ServiceEvent::ServiceResolved].
+    /// Enable or disable the use of [ServiceEvent::ServiceData] instead of [ServiceEvent::ServiceResolved].
     ///
     /// This is recommended for clients using IPv6 as it will include scope_id in the address.
-    pub fn use_service_detailed(&self, on: bool) -> Result<()> {
-        self.send_cmd(Command::SetOption(DaemonOption::UseServiceDetailed(on)))
+    pub fn use_service_data(&self, on: bool) -> Result<()> {
+        self.send_cmd(Command::SetOption(DaemonOption::UseServiceData(on)))
     }
 
     /// Proactively confirms whether a service instance still valid.
@@ -1196,7 +1196,7 @@ impl Zeroconf {
             DaemonOption::DisableInterface(if_kind) => self.disable_interface(if_kind),
             DaemonOption::MulticastLoopV4(on) => self.set_multicast_loop_v4(on),
             DaemonOption::MulticastLoopV6(on) => self.set_multicast_loop_v6(on),
-            DaemonOption::UseServiceDetailed(on) => self.use_service_detailed = on,
+            DaemonOption::UseServiceData(on) => self.use_service_detailed = on,
             #[cfg(test)]
             DaemonOption::TestDownInterface(ifname) => {
                 self.test_down_interfaces.insert(ifname);
@@ -3463,7 +3463,7 @@ pub enum ServiceEvent {
 
     /// Resolved a service instance with detailed info.
     ///
-    /// Will be deprecated in the future by [ServiceEvent::ServiceDetailed].
+    /// Will be deprecated in the future by [ServiceEvent::ServiceData].
     ServiceResolved(ServiceInfo),
 
     /// Resolved a service instance in a ResolvedService struct.
@@ -3633,7 +3633,7 @@ enum DaemonOption {
     DisableInterface(Vec<IfKind>),
     MulticastLoopV4(bool),
     MulticastLoopV6(bool),
-    UseServiceDetailed(bool),
+    UseServiceData(bool),
     #[cfg(test)]
     TestDownInterface(String),
     #[cfg(test)]
@@ -4802,7 +4802,7 @@ mod tests {
 
         // start a client
         let client = ServiceDaemon::new().expect("failed to start client");
-        client.use_service_detailed(true).unwrap();
+        client.use_service_data(true).unwrap();
 
         let receiver = client.browse(ty_domain).unwrap();
 

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -2464,10 +2464,10 @@ fn timed_println(msg: String) {
 }
 
 #[test]
-fn test_use_service_detailed() {
+fn test_use_service_data() {
     // start a server
-    let ty_domain = "_svc-detailed._udp.local.";
-    let host_name = "service_detailed.local.";
+    let ty_domain = "_svc-data._udp.local.";
+    let host_name = "service_data.local.";
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
@@ -2497,7 +2497,7 @@ fn test_use_service_detailed() {
     let receiver = client.browse(ty_domain).unwrap();
     let timeout = Duration::from_secs(2);
     let mut got_resolved = false;
-    let mut got_detailed = false;
+    let mut got_data = false;
 
     while let Ok(event) = receiver.recv_timeout(timeout) {
         match event {
@@ -2506,7 +2506,7 @@ fn test_use_service_detailed() {
                 break;
             }
             ServiceEvent::ServiceData(_) => {
-                got_detailed = true;
+                got_data = true;
                 break;
             }
             _ => {}
@@ -2517,21 +2517,18 @@ fn test_use_service_detailed() {
         got_resolved,
         "Should receive ServiceResolved event by default"
     );
-    assert!(
-        !got_detailed,
-        "Should not receive ServiceDetailed event by default"
-    );
+    assert!(!got_data, "Should not receive ServiceData event by default");
 
-    // Now enable use_resolved_service and test for ServiceDetailed
+    // Now enable use_resolved_service and test for ServiceData
     client.use_service_data(true).unwrap();
     let browse_chan = client.browse(ty_domain).unwrap();
-    let mut got_detailed = false;
+    let mut got_data = false;
     let mut got_resolved = false;
 
     while let Ok(event) = browse_chan.recv_timeout(timeout) {
         match event {
             ServiceEvent::ServiceData(resolved) => {
-                got_detailed = true;
+                got_data = true;
                 println!("address: {:?}", resolved.addresses);
                 let first_addr = resolved.addresses.iter().next().unwrap();
                 let HostIp::V4(ip_v4) = first_addr else {
@@ -2548,13 +2545,10 @@ fn test_use_service_detailed() {
             _ => {}
         }
     }
-    assert!(
-        got_detailed,
-        "Should receive ServiceDetailed event when enabled"
-    );
+    assert!(got_data, "Should receive ServiceData event when enabled");
     assert!(
         !got_resolved,
-        "Should not receive ServiceResolved event when detailed is enabled"
+        "Should not receive ServiceResolved event when ServiceData is enabled"
     );
 
     server1.shutdown().unwrap();
@@ -2562,10 +2556,10 @@ fn test_use_service_detailed() {
 }
 
 #[test]
-fn test_use_service_detailed_v6() {
+fn test_use_service_data_v6() {
     // start a server
-    let ty_domain = "_detailed-v6._udp.local.";
-    let host_name = "service_detailed_v6.local.";
+    let ty_domain = "_data-v6._udp.local.";
+    let host_name = "service_data_v6.local.";
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
@@ -2602,7 +2596,7 @@ fn test_use_service_detailed_v6() {
     let receiver = client.browse(ty_domain).unwrap();
     let timeout = Duration::from_secs(2);
     let mut got_resolved = false;
-    let mut got_detailed = false;
+    let mut got_data = false;
 
     while let Ok(event) = receiver.recv_timeout(timeout) {
         match event {
@@ -2611,7 +2605,7 @@ fn test_use_service_detailed_v6() {
                 break;
             }
             ServiceEvent::ServiceData(_) => {
-                got_detailed = true;
+                got_data = true;
                 break;
             }
             _ => {}
@@ -2622,21 +2616,18 @@ fn test_use_service_detailed_v6() {
         got_resolved,
         "Should receive ServiceResolved event by default"
     );
-    assert!(
-        !got_detailed,
-        "Should not receive ServiceDetailed event by default"
-    );
+    assert!(!got_data, "Should not receive ServiceData event by default");
 
-    // Now enable use_resolved_service and test for ServiceDetailed
+    // Now enable use_resolved_service and test for ServiceData
     client.use_service_data(true).unwrap();
     let browse_chan = client.browse(ty_domain).unwrap();
-    let mut got_detailed = false;
+    let mut got_data = false;
     let mut got_resolved = false;
 
     while let Ok(event) = browse_chan.recv_timeout(timeout) {
         match event {
             ServiceEvent::ServiceData(resolved) => {
-                got_detailed = true;
+                got_data = true;
                 assert!(
                     resolved.addresses.len() > 0,
                     "Should have at least one address"
@@ -2663,13 +2654,10 @@ fn test_use_service_detailed_v6() {
             _ => {}
         }
     }
-    assert!(
-        got_detailed,
-        "Should receive ServiceDetailed event when enabled"
-    );
+    assert!(got_data, "Should receive ServiceData event when enabled");
     assert!(
         !got_resolved,
-        "Should not receive ServiceResolved event when detailed is enabled"
+        "Should not receive ServiceResolved event when ServiceData is enabled"
     );
 
     server1.shutdown().unwrap();

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -2505,7 +2505,7 @@ fn test_use_service_detailed() {
                 got_resolved = true;
                 break;
             }
-            ServiceEvent::ServiceDetailed(_) => {
+            ServiceEvent::ServiceData(_) => {
                 got_detailed = true;
                 break;
             }
@@ -2530,7 +2530,7 @@ fn test_use_service_detailed() {
 
     while let Ok(event) = browse_chan.recv_timeout(timeout) {
         match event {
-            ServiceEvent::ServiceDetailed(resolved) => {
+            ServiceEvent::ServiceData(resolved) => {
                 got_detailed = true;
                 println!("address: {:?}", resolved.addresses);
                 let first_addr = resolved.addresses.iter().next().unwrap();
@@ -2610,7 +2610,7 @@ fn test_use_service_detailed_v6() {
                 got_resolved = true;
                 break;
             }
-            ServiceEvent::ServiceDetailed(_) => {
+            ServiceEvent::ServiceData(_) => {
                 got_detailed = true;
                 break;
             }
@@ -2635,7 +2635,7 @@ fn test_use_service_detailed_v6() {
 
     while let Ok(event) = browse_chan.recv_timeout(timeout) {
         match event {
-            ServiceEvent::ServiceDetailed(resolved) => {
+            ServiceEvent::ServiceData(resolved) => {
                 got_detailed = true;
                 assert!(
                     resolved.addresses.len() > 0,

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -2523,7 +2523,7 @@ fn test_use_service_detailed() {
     );
 
     // Now enable use_resolved_service and test for ServiceDetailed
-    client.use_service_detailed(true).unwrap();
+    client.use_service_data(true).unwrap();
     let browse_chan = client.browse(ty_domain).unwrap();
     let mut got_detailed = false;
     let mut got_resolved = false;
@@ -2628,7 +2628,7 @@ fn test_use_service_detailed_v6() {
     );
 
     // Now enable use_resolved_service and test for ServiceDetailed
-    client.use_service_detailed(true).unwrap();
+    client.use_service_data(true).unwrap();
     let browse_chan = client.browse(ty_domain).unwrap();
     let mut got_detailed = false;
     let mut got_resolved = false;


### PR DESCRIPTION
I was pondering about whether `ServiceDetailed` is the best name for its purpose. After some discussions with AI, I think `ServiceData` seems to work better. 