### PR TITLE
rename HostIp to ScopedIp

### DIFF
--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -7,7 +7,7 @@ use crate::log::{debug, trace};
 use crate::{
     dns_parser::{DnsAddress, DnsPointer, DnsRecordBox, DnsSrv, InterfaceId, RRType},
     service_info::{split_sub_domain, MyIntf},
-    HostIp,
+    ScopedIp,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -125,7 +125,7 @@ impl DnsCache {
     ///
     /// Note that the keys in the returned HashMap are the same hostname, with different cases
     /// of letters (e.g. "example.local.", "Example.local.", "EXAMPLE.local.").
-    pub(crate) fn get_addresses_for_host(&self, host: &str) -> HashMap<String, HashSet<HostIp>> {
+    pub(crate) fn get_addresses_for_host(&self, host: &str) -> HashMap<String, HashSet<ScopedIp>> {
         let hostname_lower = host.to_lowercase();
         let mut result = HashMap::new();
 
@@ -326,7 +326,7 @@ impl DnsCache {
 
     /// Iterates all ADDR records and remove ones that expired.
     /// Returns the expired ones in a map of names and addresses.
-    pub(crate) fn evict_expired_addr(&mut self, now: u64) -> HashMap<String, HashSet<HostIp>> {
+    pub(crate) fn evict_expired_addr(&mut self, now: u64) -> HashMap<String, HashSet<ScopedIp>> {
         let mut removed = HashMap::new();
 
         self.addr.retain(|_, records| {
@@ -609,7 +609,7 @@ impl DnsCache {
     pub(crate) fn refresh_due_hostname_resolutions(
         &mut self,
         hostname: &str,
-    ) -> HashSet<(String, HostIp)> {
+    ) -> HashSet<(String, ScopedIp)> {
         let now = current_time_millis();
 
         self.addr

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -47,13 +47,16 @@ impl From<&Interface> for InterfaceId {
     }
 }
 
-/// An IPv4 address used in `HostIp`.
+/// An IPv4 address used in `ScopedIp`.
+///
+/// Note: IPv4 addresses don't have scope IDs, but this type is named for consistency
+/// with the rest of the addressing system.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct HostIpV4 {
+pub struct ScopedIpV4 {
     addr: Ipv4Addr,
 }
 
-impl HostIpV4 {
+impl ScopedIpV4 {
     /// Returns the IPv4 address.
     pub const fn addr(&self) -> &Ipv4Addr {
         &self.addr
@@ -62,12 +65,12 @@ impl HostIpV4 {
 
 /// An IPv6 address with scope_id (interface identifier).
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct HostIpV6 {
+pub struct ScopedIpV6 {
     addr: Ipv6Addr,
     scope_id: InterfaceId,
 }
 
-impl HostIpV6 {
+impl ScopedIpV6 {
     /// Returns the IPv6 address.
     pub const fn addr(&self) -> &Ipv6Addr {
         &self.addr
@@ -79,36 +82,36 @@ impl HostIpV6 {
     }
 }
 
-/// A host IP address, either IPv4 or IPv6, that supports scope_id for IPv6.
+/// An IP address, either IPv4 or IPv6, that supports scope_id for IPv6.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[non_exhaustive]
-pub enum HostIp {
-    V4(HostIpV4),
-    V6(HostIpV6),
+pub enum ScopedIp {
+    V4(ScopedIpV4),
+    V6(ScopedIpV6),
 }
 
-impl HostIp {
+impl ScopedIp {
     pub const fn to_ip_addr(&self) -> IpAddr {
         match self {
-            HostIp::V4(v4) => IpAddr::V4(v4.addr),
-            HostIp::V6(v6) => IpAddr::V6(v6.addr),
+            ScopedIp::V4(v4) => IpAddr::V4(v4.addr),
+            ScopedIp::V6(v6) => IpAddr::V6(v6.addr),
         }
     }
 
     pub const fn is_ipv4(&self) -> bool {
-        matches!(self, HostIp::V4(_))
+        matches!(self, ScopedIp::V4(_))
     }
 
     pub const fn is_ipv6(&self) -> bool {
-        matches!(self, HostIp::V6(_))
+        matches!(self, ScopedIp::V6(_))
     }
 }
 
-impl From<IpAddr> for HostIp {
+impl From<IpAddr> for ScopedIp {
     fn from(ip: IpAddr) -> Self {
         match ip {
-            IpAddr::V4(v4) => HostIp::V4(HostIpV4 { addr: v4 }),
-            IpAddr::V6(v6) => HostIp::V6(HostIpV6 {
+            IpAddr::V4(v4) => ScopedIp::V4(ScopedIpV4 { addr: v4 }),
+            IpAddr::V6(v6) => ScopedIp::V6(ScopedIpV6 {
                 addr: v6,
                 scope_id: InterfaceId::default(),
             }),
@@ -116,11 +119,11 @@ impl From<IpAddr> for HostIp {
     }
 }
 
-impl From<&Interface> for HostIp {
+impl From<&Interface> for ScopedIp {
     fn from(interface: &Interface) -> Self {
         match interface.ip() {
-            IpAddr::V4(v4) => HostIp::V4(HostIpV4 { addr: v4 }),
-            IpAddr::V6(v6) => HostIp::V6(HostIpV6 {
+            IpAddr::V4(v4) => ScopedIp::V4(ScopedIpV4 { addr: v4 }),
+            IpAddr::V6(v6) => ScopedIp::V6(ScopedIpV6 {
                 addr: v6,
                 scope_id: InterfaceId::from(interface),
             }),
@@ -128,11 +131,11 @@ impl From<&Interface> for HostIp {
     }
 }
 
-impl fmt::Display for HostIp {
+impl fmt::Display for ScopedIp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            HostIp::V4(v4) => write!(f, "{}", v4.addr),
-            HostIp::V6(v6) => {
+            ScopedIp::V4(v4) => write!(f, "{}", v4.addr),
+            ScopedIp::V6(v6) => {
                 if v6.scope_id.index != 0 {
                     #[cfg(windows)]
                     {
@@ -653,10 +656,10 @@ impl DnsAddress {
         }
     }
 
-    pub fn address(&self) -> HostIp {
+    pub fn address(&self) -> ScopedIp {
         match self.address {
-            IpAddr::V4(v4) => HostIp::V4(HostIpV4 { addr: v4 }),
-            IpAddr::V6(v6) => HostIp::V6(HostIpV6 {
+            IpAddr::V4(v4) => ScopedIp::V4(ScopedIpV4 { addr: v4 }),
+            IpAddr::V6(v6) => ScopedIp::V6(ScopedIpV6 {
                 addr: v6,
                 scope_id: self.interface_id.clone(),
             }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ mod error;
 mod service_daemon;
 mod service_info;
 
-pub use dns_parser::{HostIp, HostIpV4, HostIpV6, InterfaceId, RRType};
+pub use dns_parser::{InterfaceId, RRType, ScopedIp, ScopedIpV4, ScopedIpV6};
 pub use error::{Error, Result};
 pub use service_daemon::{
     DaemonEvent, DaemonStatus, DnsNameChange, HostnameResolutionEvent, IfKind, Metrics,

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -34,8 +34,8 @@ use crate::{
     dns_cache::{current_time_millis, DnsCache},
     dns_parser::{
         ip_address_rr_type, DnsAddress, DnsEntryExt, DnsIncoming, DnsOutgoing, DnsPointer,
-        DnsRecordBox, DnsRecordExt, DnsSrv, DnsTxt, HostIp, InterfaceId, RRType, CLASS_CACHE_FLUSH,
-        CLASS_IN, FLAGS_AA, FLAGS_QR_QUERY, FLAGS_QR_RESPONSE, MAX_MSG_ABSOLUTE,
+        DnsRecordBox, DnsRecordExt, DnsSrv, DnsTxt, InterfaceId, RRType, ScopedIp,
+        CLASS_CACHE_FLUSH, CLASS_IN, FLAGS_AA, FLAGS_QR_QUERY, FLAGS_QR_RESPONSE, MAX_MSG_ABSOLUTE,
     },
     error::{e_fmt, Error, Result},
     service_info::{split_sub_domain, DnsRegistry, MyIntf, Probe, ServiceInfo, ServiceStatus},
@@ -3485,9 +3485,9 @@ pub enum HostnameResolutionEvent {
     /// Started searching for the ip address of a hostname.
     SearchStarted(String),
     /// One or more addresses for a hostname has been found.
-    AddressesFound(String, HashSet<HostIp>),
+    AddressesFound(String, HashSet<ScopedIp>),
     /// One or more addresses for a hostname has been removed.
-    AddressesRemoved(String, HashSet<HostIp>),
+    AddressesRemoved(String, HashSet<ScopedIp>),
     /// The search for the ip address of a hostname has timed out.
     SearchTimeout(String),
     /// Stopped searching for the ip address of a hostname.
@@ -4310,8 +4310,8 @@ mod tests {
     };
     use crate::{
         dns_parser::{
-            DnsIncoming, DnsOutgoing, DnsPointer, HostIp, InterfaceId, RRType, CLASS_IN, FLAGS_AA,
-            FLAGS_QR_RESPONSE,
+            DnsIncoming, DnsOutgoing, DnsPointer, InterfaceId, RRType, ScopedIp, CLASS_IN,
+            FLAGS_AA, FLAGS_QR_RESPONSE,
         },
         service_daemon::{add_answer_of_service, check_hostname},
     };
@@ -4552,7 +4552,7 @@ mod tests {
         // Create a mDNS server
         let server = ServiceDaemon::new().expect("Failed to create server");
         let hostname = "addr_remove_host._tcp.local.";
-        let service_ip_addr: HostIp = my_ip_interfaces(false)
+        let service_ip_addr: ScopedIp = my_ip_interfaces(false)
             .iter()
             .find(|iface| iface.ip().is_ipv4())
             .map(|iface| iface.ip().into())

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "logging")]
 use crate::log::debug;
 use crate::{
-    dns_parser::{DnsRecordBox, DnsRecordExt, DnsSrv, HostIp, RRType},
+    dns_parser::{DnsRecordBox, DnsRecordExt, DnsSrv, RRType, ScopedIp},
     Error, InterfaceId, Result,
 };
 use if_addrs::IfAddr;
@@ -411,7 +411,7 @@ impl ServiceInfo {
 
     /// Consumes self and returns a resolved service, i.e. a lite version of `ServiceInfo`.
     pub fn as_resolved_service(self) -> ResolvedService {
-        let addresses: HashSet<HostIp> = self.addresses.into_iter().map(|a| a.into()).collect();
+        let addresses: HashSet<ScopedIp> = self.addresses.into_iter().map(|a| a.into()).collect();
         ResolvedService {
             ty_domain: self.ty_domain,
             sub_ty_domain: self.sub_domain,
@@ -1191,7 +1191,7 @@ pub struct ResolvedService {
     pub port: u16,
 
     /// Addresses of the service. IPv4 or IPv6 addresses.
-    pub addresses: HashSet<HostIp>,
+    pub addresses: HashSet<ScopedIp>,
 
     /// Properties of the service, decoded from TXT record.
     pub txt_properties: TxtProperties,

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1,6 +1,6 @@
 use if_addrs::{IfAddr, Interface};
 use mdns_sd::{
-    DaemonEvent, DaemonStatus, HostIp, HostnameResolutionEvent, IfKind, IntoTxtProperties,
+    DaemonEvent, DaemonStatus, HostnameResolutionEvent, IfKind, IntoTxtProperties, ScopedIp,
     ServiceDaemon, ServiceEvent, ServiceInfo, TxtProperty, UnregisterStatus,
 };
 use std::collections::{HashMap, HashSet};
@@ -1331,7 +1331,7 @@ fn test_shutdown() {
 fn test_hostname_resolution() {
     let d = ServiceDaemon::new().expect("Failed to create daemon");
     let hostname = "my_host._tcp.local.";
-    let service_ip_addr: HostIp = my_ip_interfaces()
+    let service_ip_addr: ScopedIp = my_ip_interfaces()
         .iter()
         .find(|iface| iface.ip().is_ipv4())
         .map(|iface| iface.into())
@@ -1370,7 +1370,7 @@ fn test_hostname_resolution() {
 fn test_hostname_resolution_case_insensitive() {
     let d = ServiceDaemon::new().expect("Failed to create daemon");
     let hostname = "My_casE_HOST.local.";
-    let service_ip_addr: HostIp = my_ip_interfaces()
+    let service_ip_addr: ScopedIp = my_ip_interfaces()
         .iter()
         .find(|iface| iface.ip().is_ipv4())
         .map(|iface| iface.into())
@@ -2531,7 +2531,7 @@ fn test_use_service_data() {
                 got_data = true;
                 println!("address: {:?}", resolved.addresses);
                 let first_addr = resolved.addresses.iter().next().unwrap();
-                let HostIp::V4(ip_v4) = first_addr else {
+                let ScopedIp::V4(ip_v4) = first_addr else {
                     assert!(false, "Address should be IPv4");
                     return;
                 };
@@ -2635,7 +2635,7 @@ fn test_use_service_data_v6() {
                 let first_addr = resolved.addresses.into_iter().next().unwrap();
                 assert!(first_addr.is_ipv6(), "Address should be IPv6");
                 println!("Resolved address: {}", first_addr);
-                let HostIp::V6(ip_v6) = first_addr else {
+                let ScopedIp::V6(ip_v6) = first_addr else {
                     assert!(false, "Address should be IPv6");
                     return;
                 };


### PR DESCRIPTION
I think `ScopedIp` better represents its purpose. Rename it before it goes into public API in the next release.