### PR TITLE
merge ServiceData with ServiceResolved

### DIFF
--- a/examples/query.rs
+++ b/examples/query.rs
@@ -29,8 +29,6 @@ fn main() {
 
     // Create a daemon
     let mdns = ServiceDaemon::new().expect("Failed to create daemon");
-    mdns.use_service_data(true)
-        .expect("Failed to use ServiceData");
 
     // Browse for the service type
     let receiver = mdns.browse(&service_type).expect("Failed to browse");
@@ -38,7 +36,7 @@ fn main() {
     let now = std::time::Instant::now();
     while let Ok(event) = receiver.recv() {
         match event {
-            ServiceEvent::ServiceData(info) => {
+            ServiceEvent::ServiceResolved(info) => {
                 println!(
                     "At {:?}: Resolved a new service: {}\n host: {}\n port: {}",
                     now.elapsed(),

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -105,6 +105,13 @@ impl ScopedIp {
     pub const fn is_ipv6(&self) -> bool {
         matches!(self, ScopedIp::V6(_))
     }
+
+    pub const fn is_loopback(&self) -> bool {
+        match self {
+            ScopedIp::V4(v4) => v4.addr.is_loopback(),
+            ScopedIp::V6(v6) => v6.addr.is_loopback(),
+        }
+    }
 }
 
 impl From<IpAddr> for ScopedIp {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,6 @@
 //! // Create a daemon
 //! let mdns = ServiceDaemon::new().expect("Failed to create daemon");
 //!
-//! // Use recently added `ServiceEvent::ServiceData`.
-//! mdns.use_service_data(true).expect("Failed to use ServiceData");
-//!
 //! // Browse for a service type.
 //! let service_type = "_mdns-sd-my-test._udp.local.";
 //! let receiver = mdns.browse(service_type).expect("Failed to browse");
@@ -53,7 +50,7 @@
 //! std::thread::spawn(move || {
 //!     while let Ok(event) = receiver.recv() {
 //!         match event {
-//!             ServiceEvent::ServiceData(resolved) => {
+//!             ServiceEvent::ServiceResolved(resolved) => {
 //!                 println!("Resolved a new service: {}", resolved.fullname);
 //!             }
 //!             other_event => {

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -336,7 +336,7 @@ impl ServiceInfo {
     }
 
     /// Returns whether the service info is ready to be resolved.
-    pub(crate) fn is_ready(&self) -> bool {
+    pub(crate) fn _is_ready(&self) -> bool {
         let some_missing = self.ty_domain.is_empty()
             || self.fullname.is_empty()
             || self.server.is_empty()
@@ -357,16 +357,16 @@ impl ServiceInfo {
         encode_txt(self.get_properties().iter())
     }
 
-    pub(crate) fn set_port(&mut self, port: u16) {
+    pub(crate) fn _set_port(&mut self, port: u16) {
         self.port = port;
     }
 
-    pub(crate) fn set_hostname(&mut self, hostname: String) {
+    pub(crate) fn _set_hostname(&mut self, hostname: String) {
         self.server = normalize_hostname(hostname);
     }
 
     /// Returns true if properties are updated.
-    pub(crate) fn set_properties_from_txt(&mut self, txt: &[u8]) -> bool {
+    pub(crate) fn _set_properties_from_txt(&mut self, txt: &[u8]) -> bool {
         let properties = decode_txt_unique(txt);
         if self.txt_properties.properties != properties {
             self.txt_properties = TxtProperties { properties };
@@ -376,7 +376,7 @@ impl ServiceInfo {
         }
     }
 
-    pub(crate) fn set_subtype(&mut self, subtype: String) {
+    pub(crate) fn _set_subtype(&mut self, subtype: String) {
         self.sub_domain = Some(subtype);
     }
 
@@ -1206,6 +1206,52 @@ impl ResolvedService {
             || self.addresses.is_empty();
         !some_missing
     }
+
+    pub fn get_subtype(&self) -> &Option<String> {
+        &self.sub_ty_domain
+    }
+
+    pub fn get_fullname(&self) -> &str {
+        &self.fullname
+    }
+
+    pub fn get_hostname(&self) -> &str {
+        &self.host
+    }
+
+    pub fn get_port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn get_addresses(&self) -> &HashSet<ScopedIp> {
+        &self.addresses
+    }
+
+    pub fn get_addresses_v4(&self) -> HashSet<Ipv4Addr> {
+        self.addresses
+            .iter()
+            .filter_map(|ip| match ip {
+                ScopedIp::V4(ipv4) => Some(*ipv4.addr()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    pub fn get_properties(&self) -> &TxtProperties {
+        &self.txt_properties
+    }
+
+    pub fn get_property(&self, key: &str) -> Option<&TxtProperty> {
+        self.txt_properties.get(key)
+    }
+
+    pub fn get_property_val(&self, key: &str) -> Option<Option<&[u8]>> {
+        self.txt_properties.get_property_val(key)
+    }
+
+    pub fn get_property_val_str(&self, key: &str) -> Option<&str> {
+        self.txt_properties.get_property_val_str(key)
+    }
 }
 
 #[cfg(test)]
@@ -1305,7 +1351,7 @@ mod tests {
         // ServiceInfo removes duplicated keys and keeps only the first one.
         let mut service_info =
             ServiceInfo::new("_test._tcp", "prop_test", "localhost", "", 1234, None).unwrap();
-        service_info.set_properties_from_txt(&encoded);
+        service_info._set_properties_from_txt(&encoded);
         assert_eq!(service_info.get_properties().len(), 1);
 
         // Verify the only one property.

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -1207,22 +1207,27 @@ impl ResolvedService {
         !some_missing
     }
 
-    pub fn get_subtype(&self) -> &Option<String> {
+    #[inline]
+    pub const fn get_subtype(&self) -> &Option<String> {
         &self.sub_ty_domain
     }
 
+    #[inline]
     pub fn get_fullname(&self) -> &str {
         &self.fullname
     }
 
+    #[inline]
     pub fn get_hostname(&self) -> &str {
         &self.host
     }
 
+    #[inline]
     pub fn get_port(&self) -> u16 {
         self.port
     }
 
+    #[inline]
     pub fn get_addresses(&self) -> &HashSet<ScopedIp> {
         &self.addresses
     }
@@ -1237,10 +1242,12 @@ impl ResolvedService {
             .collect()
     }
 
+    #[inline]
     pub fn get_properties(&self) -> &TxtProperties {
         &self.txt_properties
     }
 
+    #[inline]
     pub fn get_property(&self, key: &str) -> Option<&TxtProperty> {
         self.txt_properties.get(key)
     }


### PR DESCRIPTION
In release 0.14.0, we introduced `ServiceEvent::ServiceData` to support scope_id in IPv6 (`ScopedIp`), and plan to deprecate `ServiceEvent::ServiceResolved` in the next breaking-change release. 

I think that change made thing quite complicated. This PR is to finish the deprecation, and does one more thing:  renamed `ServiceData` back to `ServiceResolved`. 

The end result is: we have a single `ServiceEvent::ServiceResolved(ResolvedService)` going forward.  For most users on the client side, the important change is that the resolved data struct changed from `ServiceInfo` to `ResolvedService`.

And hence, `user_service_data()` is no longer needed. To be more backward compatible, I added a few access functions for `ResolvedService`. 

On the server (publish / register) side, we still use `ServiceInfo`. 

Please share your comments or thoughts, I hope this is a better change for the longer term, but I could be wrong.
