### PR TITLE
feat: impl AsIpAddrs for Box<dyn AsIpAddrs>

### DIFF
--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -500,6 +500,12 @@ impl AsIpAddrs for std::net::IpAddr {
     }
 }
 
+impl AsIpAddrs for Box<dyn AsIpAddrs> {
+    fn as_ip_addrs(&self) -> Result<HashSet<IpAddr>> {
+        self.as_ref().as_ip_addrs()
+    }
+}
+
 /// Represents properties in a TXT record.
 ///
 /// The key string of a property is case insensitive, and only


### PR DESCRIPTION
This allows users to pass a dynamically typed AsIpAddrs set.

For example, this allows the following code to run :

```rust
 let local_ip: Box<dyn mdns_sd::AsIpAddrs> = match local_ip_address::local_ip() {
    Ok(ip) => Box::new(ip),
    Err(e) => {
        error!(
            "Could not figure out local ip, mdns will have to try to figure it out by itself : {e}"
        );
        Box::new(())
    }
};

let service_info = ServiceInfo::new(
    "service_name",
    "instance_name",
    "hostname",
    local_ip,
    8080,
    None,
)
.expect("ServiceInfo creation should not fail with valid inputs");
```