### PR TITLE
Add `with_timeout` API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1.48.0", defalut-features = false, features = ["macros", "t
 
 [dev-dependencies]
 env_logger = { version = "= 0.10.2", default-features = false, features= ["humantime"] }
+tokio = { version = "1.48.0", defalut-features = false, features = ["macros", "rt"]}
 fastrand = "2.3"
 humantime = "2.1"
 test-log = "= 0.2.14"

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -3777,7 +3777,7 @@ fn call_hostname_resolution_listener(
 /// Returns valid network interfaces in the host system.
 /// Operational down interfaces are excluded.
 /// Loopback interfaces are excluded if `with_loopback` is false.
-fn my_ip_interfaces(with_loopback: bool) -> Vec<Interface> {
+pub(crate) fn my_ip_interfaces(with_loopback: bool) -> Vec<Interface> {
     if_addrs::get_if_addrs()
         .unwrap_or_default()
         .into_iter()


### PR DESCRIPTION
First, sorry for the long delay, but my life has been quite busy lately. 

This PR aims to fix #320, but it also serves as a good foundation for further discussion. Based on the considerations outlined [here](https://github.com/keepsimple1/mdns-sd/issues/320#issuecomment-2691965658), no wrapper was initially considered. However, I’d like to propose my solution regardless. If this PR is not deemed acceptable, feel free to close it at any time. 

I will now walk through the implementation details in a Q&A format.

**Why not futures-utils?**

`futures-utils` seems unmaintained. The most recent release was over a year ago. Additionally, there’s no asynchronous timer in `futures-utils`, meaning an external dependency would still be required, resulting in two dependencies instead of one.

**Why tokio?**

`tokio` is updated daily, includes all the necessary tools, and requires only two features to compile. Therefore, the build process is pretty fast.

**Could there be conflicts if we use a different version of `flume` than the one we re-export?**

Yes, because `with_timeout` uses the same version of `flume` that we re-export, ensuring it remains in sync with future updates.

**Why not `with_deadline` API?**

The `recv_deadline` function relies on `std::time::Instant`, a monotonic clock that behaves differently across operating systems. A monotonic clock measures elapsed time, but does not correspond to a specific point in time, so unusable for an `async` context.  [Here](https://doc.rust-lang.org/std/time/struct.Instant.html) a more detailed description. That is why I chose not to implement the API. Although, we can also use something like `instant.checked_duration_since(Instant::now())` to retrieve a `Duration`, I believe this approach reduces the implementation freedom of a developer.

Additionally, the API is behind the `async` feature, including the tests. Let me know what you think about my idea @keepsimple1, thank you! 
