### PR TITLE
Handle empty packets from send_dns_outgoing

### DIFF
--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -1946,8 +1946,11 @@ impl Zeroconf {
             );
         }
 
-        // `out` data is non-empty, hence we can do this.
-        send_dns_outgoing(&out, intf, sock).remove(0)
+        // Only (at most) one packet is expected to be sent out.
+        send_dns_outgoing(&out, intf, sock)
+            .into_iter()
+            .next()
+            .unwrap_or_default()
     }
 
     /// Binds a channel `listener` to querying mDNS hostnames.
@@ -3771,6 +3774,8 @@ fn my_ip_interfaces(with_loopback: bool) -> Vec<Interface> {
         .collect()
 }
 
+/// Send an outgoing mDNS query or response, and returns the packet bytes.
+/// Returns empty vec if no valid interface address is found.
 fn send_dns_outgoing(out: &DnsOutgoing, my_intf: &MyIntf, sock: &PktInfoUdpSocket) -> Vec<Vec<u8>> {
     let if_name = &my_intf.name;
 


### PR DESCRIPTION
This patch is to fix the bug in issue #406 .