### PR TITLE
Add a custom port option

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ pub use dns_parser::{InterfaceId, RRType, ScopedIp, ScopedIpV4, ScopedIpV6};
 pub use error::{Error, Result};
 pub use service_daemon::{
     DaemonEvent, DaemonStatus, DnsNameChange, HostnameResolutionEvent, IfKind, Metrics,
-    ServiceDaemon, ServiceEvent, UnregisterStatus, IP_CHECK_INTERVAL_IN_SECS_DEFAULT,
+    ServiceDaemon, ServiceEvent, UnregisterStatus, IP_CHECK_INTERVAL_IN_SECS_DEFAULT, MDNS_PORT,
     SERVICE_NAME_LEN_MAX_DEFAULT, VERIFY_TIMEOUT_DEFAULT,
 };
 pub use service_info::{


### PR DESCRIPTION
* Add a custom port option to Daemon ( new_with_port ). This is mostly a development/testing option, making it easier to deploy and run end-to-end tests in contested networks, and also on a host where system mDNS services are already listening.

The runtime overhead of the extra config is fairly benign, carrying only the u16 port in ZeroConf struct