### PR TITLE
feat: use Self on impl return of itself

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -197,7 +197,7 @@ pub enum RRType {
 
 impl RRType {
     /// Converts `u16` into `RRType` if possible.
-    pub const fn from_u16(value: u16) -> Option<RRType> {
+    pub const fn from_u16(value: u16) -> Option<Self> {
         match value {
             1 => Some(RRType::A),
             5 => Some(RRType::CNAME),


### PR DESCRIPTION
Every implementation that returns self is marked with `Self`, not the explicit way. This is the sole location that isn't like the others.
This is a trivial PR of maintaining the code style, feel free to close if not appropriate.

This change is a part of the [clippy::use_self](https://rust-lang.github.io/rust-clippy/master/index.html#use_self) lint, there are other 35 instances where the explicit type could be replaced by `Self` (although not in the return position), some places maintain this and others do not, if this is a wanted change I could replace them and also add the lint to the CI!
