### PR TITLE
exmaples: add --verify option in the query example

### DIFF
--- a/examples/query.rs
+++ b/examples/query.rs
@@ -27,6 +27,12 @@ fn main() {
     };
     service_type.push_str(".local.");
 
+    // Showcase `verify` functionality for IPv4 addresses
+    let should_verify = match std::env::args().nth(2) {
+        Some(arg) if arg == "--verify" => true,
+        _ => false,
+    };
+
     // Create a daemon
     let mdns = ServiceDaemon::new().expect("Failed to create daemon");
 
@@ -44,12 +50,35 @@ fn main() {
                     info.host,
                     info.port,
                 );
+                let mut found_ipv4 = false;
                 for addr in info.addresses.iter() {
                     println!(" Address: {addr}");
+                    if addr.is_ipv4() {
+                        found_ipv4 = true;
+                    }
                 }
                 for prop in info.txt_properties.iter() {
                     println!(" Property: {}", prop);
                 }
+
+                if should_verify && found_ipv4 {
+                    println!("Will verify after 3 seconds...");
+                    std::thread::sleep(std::time::Duration::from_secs(3));
+
+                    let instance_fullname = info.fullname;
+                    let timeout = std::time::Duration::from_secs(2);
+                    if let Err(e) = mdns.verify(instance_fullname, timeout) {
+                        println!("Verify failed: {}", e);
+                    } else {
+                        println!("Verify started");
+                    }
+                }
+            }
+            ServiceEvent::ServiceRemoved(service_type, fullname) => {
+                println!(
+                    "At {:?}: ** service removed **: {service_type}: {fullname}",
+                    now.elapsed(),
+                );
             }
             other_event => {
                 println!("At {:?}: {:?}", now.elapsed(), &other_event);
@@ -59,9 +88,12 @@ fn main() {
 }
 
 fn print_usage() {
-    println!("Usage: cargo run --example query <service_type_without_domain_postfix>");
+    println!("Usage: cargo run --example query <service_type_without_domain_postfix> [--verify]");
     println!("Example: ");
     println!("cargo run --example query _my-service._udp");
+    println!();
+    println!("Options:");
+    println!("--verify: make the client attempt to verify IPv4 addresses of resolved services.");
     println!();
     println!("You can also do a meta-query per RFC 6763 to find which services are available:");
     println!("cargo run --example query _services._dns-sd._udp");


### PR DESCRIPTION
Address the [comments](https://github.com/keepsimple1/mdns-sd/issues/54#issuecomment-3650465536
) in #54 .    

Now the query example supports `--verify` option ([doc](https://docs.rs/mdns-sd/0.17.1/mdns_sd/struct.ServiceDaemon.html#method.verify)) to show how it can be used for reconfirming service IPv4 addresses: 

```
$ cargo run --example query   
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/examples/query`
Usage: cargo run --example query <service_type_without_domain_postfix> [--verify]
Example: 
cargo run --example query _my-service._udp

Options:
--verify: make the client attempt to verify IPv4 addresses of resolved services.

You can also do a meta-query per RFC 6763 to find which services are available:
cargo run --example query _services._dns-sd._udp
```

Note that `unregister` already exists in the register example:
```
$ cargo run --example register
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/examples/register`
Usage:
cargo run --example register <service_type> <instance_name> <hostname> [options]

Options:

--unregister: automatically unregister after 2 seconds
--disable-ipv6: not to use IPv6 interfaces.
--logfile: write debug log to a file instead of stderr. The logfile is named 'mdns-register-<timestamp>.log'.

For example:
cargo run --example register _my-hello._udp instance1 host1

To see the debug log, set the RUST_LOG environment variable and write a logfile:
RUST_LOG=mdns_sd=debug cargo run --example register _my-hello._udp instance1 host1 --logfile
``` 