### PR TITLE
feat: `reuseport` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,10 @@ categories = ["network-programming"]
 description = "mDNS Service Discovery library with no async runtime dependency"
 
 [features]
+reuseport = []
 async = ["flume/async"]
 logging = ["log"]
-default = ["async", "logging"]
+default = ["reuseport", "async", "logging"]
 
 [dependencies]
 fastrand = "2.3"

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -721,7 +721,7 @@ fn new_socket(addr: SocketAddr, non_block: bool) -> Result<PktInfoUdpSocket> {
 
     fd.set_reuse_address(true)
         .map_err(|e| e_fmt!("set ReuseAddr failed: {}", e))?;
-    #[cfg(unix)] // this is currently restricted to Unix's in socket2
+    #[cfg(all(unix, feature = "reuseport"))] // this is currently restricted to Unix's in socket2
     fd.set_reuse_port(true)
         .map_err(|e| e_fmt!("set ReusePort failed: {}", e))?;
 


### PR DESCRIPTION
Add a default feature `reuseport` to control if `SO_REUSEPORT` should be used. Useful for old Linux kernels (before 3.9).

For more context, see #413 