### PR TITLE
fix: only add scope to unicast link local v6 addresses when printing

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -8,6 +8,7 @@
 use crate::log::trace;
 
 use crate::error::{e_fmt, Error, Result};
+use crate::service_info::is_unicast_link_local;
 
 use if_addrs::Interface;
 
@@ -143,7 +144,7 @@ impl fmt::Display for ScopedIp {
         match self {
             ScopedIp::V4(v4) => write!(f, "{}", v4.addr),
             ScopedIp::V6(v6) => {
-                if v6.scope_id.index != 0 {
+                if v6.scope_id.index != 0 && is_unicast_link_local(&v6.addr) {
                     #[cfg(windows)]
                     {
                         write!(f, "{}%{}", v6.addr, v6.scope_id.index)

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -1233,7 +1233,7 @@ pub(crate) fn split_sub_domain(domain: &str) -> (&str, Option<&str>) {
 /// stable on the current mdns-sd Rust version (1.71.0).
 ///
 /// https://github.com/rust-lang/rust/blob/9fc6b43126469e3858e2fe86cafb4f0fd5068869/library/core/src/net/ip_addr.rs#L1684
-fn is_unicast_link_local(addr: &Ipv6Addr) -> bool {
+pub(crate) fn is_unicast_link_local(addr: &Ipv6Addr) -> bool {
     (addr.segments()[0] & 0xffc0) == 0xfe80
 }
 


### PR DESCRIPTION
The scope id only makes sense in case the address is a v6 uni-cast link local address.

Before the change the output of the query example, facing multiple ipv6 addresses with different scopes would be:

```
At 7.939648ms: Resolved a new service: FritzBoxRepeater._fbox._tcp.local.
 host: FritzBoxRepeater.fritz.box.
 port: 49000
 Address: 192.168.178.89
 Address: fd00::ca0e:14ff:feff:416%enp12s0 <- is an ULA (Unique Local Address, fc00::/7)
 Address: 2003:e8:bf1e:9b00:ca0e:14ff:feff:416%enp12s0 <- is globally scoped
 Address: fe80::ca0e:14ff:feff:416%enp12s0 <- only here it makes sense
 ```
 
 After:
 ```
 At 6.967689ms: Resolved a new service: FritzBoxRepeater._fbox._tcp.local.
 host: FritzBoxRepeater.fritz.box.
 port: 49000
 Address: 2003:e8:bf1e:9b00:ca0e:14ff:feff:416
 Address: fd00::ca0e:14ff:feff:416
 Address: 192.168.178.89
 Address: fe80::ca0e:14ff:feff:416%enp12s0
 ```
