### PR TITLE
Try out lower mio version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ fastrand = "2.3"
 flume = { version = "0.11", default-features = false } # channel between threads
 if-addrs = { version = "0.14", features = ["link-local"] } # get local IP addresses
 log = { version = "0.4", optional = true }             # logging
-mio = { version = "1.1", features = ["os-poll", "net"] }  # select/poll sockets
+mio = { version = "1.0.4", features = ["os-poll", "net"] }  # select/poll sockets
 socket2 = { version = "0.6", features = ["all"] }      # socket APIs
 socket-pktinfo = "0.3.2"
 


### PR DESCRIPTION
In some environments, `mio` v1.1 conflicts with the user's runtime. Trying out a lower version of `mio`.