### PR TITLE
fix: invert reuseport feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ categories = ["network-programming"]
 description = "mDNS Service Discovery library with no async runtime dependency"
 
 [features]
-# Disable SO_REUSEPORT socket option for older Linux kernels (before v3.9) that don't support it.
-no_reuseport = []
 async = ["flume/async"]
 logging = ["log"]
 default = ["async", "logging"]

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -741,9 +741,13 @@ fn new_socket(addr: SocketAddr, non_block: bool) -> Result<PktInfoUdpSocket> {
 
     fd.set_reuse_address(true)
         .map_err(|e| e_fmt!("set ReuseAddr failed: {}", e))?;
-    #[cfg(all(unix, not(feature = "no_reuseport")))]
-    fd.set_reuse_port(true)
-        .map_err(|e| e_fmt!("set ReusePort failed: {}", e))?;
+    #[cfg(unix)]
+    if let Err(e) = fd.set_reuse_port(true) {
+        debug!(
+            "SO_REUSEPORT is not supported, continuing without it: {}",
+            e
+        );
+    }
 
     if non_block {
         fd.set_nonblocking(true)


### PR DESCRIPTION
Address issue #428 .

# Problem: 
The reuseport feature added in #414 introduced a backward compatibility issue. 

Users who depend on this crate with `default_features = false` would silently lose the `SO_REUSEPORT` socket option. This could cause socket bind failures on systems where SO_REUSEPORT is required for multicast port sharing (e.g., macOS/BSD).

# Fix:
~This PR inverts the feature to `no_reuseport`: instead of opting in to `SO_REUSEPORT` via a default feature, users on old kernels opt out by enabling `no_reuseport`. This ensures `default_features = false` users retain the same behavior as before #414.~ 
This PR removes the feature `reuseport`.  When `set_reuseport` fails, we log it and move on. If this causes any other problems, we will catch them down the road (very quickly I think).

# Migration
If you need to disable SO_REUSEPORT (e.g., old Linux kernels before 3.9): ~use `features = ["no_reuseport"]`.~. Remove the use of the feature, and it will be handled. 