### PR TITLE
fix: Refresh of A and AAAA records

### DIFF
--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -611,7 +611,7 @@ impl DnsCache {
         for hostname in hostnames_browsed {
             let refresh_timers: HashSet<u64> = self
                 .addr
-                .get_mut(&hostname)
+                .get_mut(&hostname.to_lowercase())
                 .into_iter()
                 .flatten()
                 .filter_map(|record| record.record.updated_refresh_time(now))


### PR DESCRIPTION
I was observing random flapping for services when browsing for a longer time. I did some debugging and digging. The root cause: when looking for address records to refresh we didn't normalize the host-name to lowercase, but we store those records keyed by the host-name in lowercase.

In a query example one could observe the following:

```
At 247.012365348s: ** service removed **: _test._tcp.local.: MyTestService._test._tcp.local.
At 247.512825108s: Resolved a new service: MyTestService._test._tcp.local.
 host: MyHostName.local.
 port: 3000
 Address: 192.168.178.95
 Property: dis=and
 Property: dat=
```
I've tracked it down to A / AAAA records not being refreshed, due to the root cause described above.