### PR TITLE
refactoring: ScopedIpV4 to use multiple InterfaceIds

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -21,6 +21,7 @@ use std::{
     collections::HashMap,
     convert::TryInto,
     fmt,
+    hash::{Hash, Hasher},
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     str,
     time::SystemTime,
@@ -64,24 +65,56 @@ impl From<&Interface> for InterfaceId {
     }
 }
 
-/// An IPv4 address with an interface identifier.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+/// An IPv4 address with interface identifiers indicating which interfaces discovered it.
+///
+/// Two `ScopedIpV4` values are considered equal if their addresses are equal,
+/// regardless of which interfaces discovered them.
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct ScopedIpV4 {
     addr: Ipv4Addr,
-    /// The `interface_id` indicates which interface this address is associated with.
-    interface_id: InterfaceId,
+    /// The interfaces this address was discovered on.
+    interface_ids: Vec<InterfaceId>,
+}
+
+impl PartialEq for ScopedIpV4 {
+    fn eq(&self, other: &Self) -> bool {
+        self.addr == other.addr
+    }
+}
+
+impl Eq for ScopedIpV4 {}
+
+impl Hash for ScopedIpV4 {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.addr.hash(state);
+    }
 }
 
 impl ScopedIpV4 {
+    /// Creates a new `ScopedIpV4` with a single interface identifier.
+    pub fn new(addr: Ipv4Addr, interface_id: InterfaceId) -> Self {
+        Self {
+            addr,
+            interface_ids: vec![interface_id],
+        }
+    }
+
     /// Returns the IPv4 address.
     pub const fn addr(&self) -> &Ipv4Addr {
         &self.addr
     }
 
-    /// Returns the interface this address is found on.
-    pub const fn interface_id(&self) -> &InterfaceId {
-        &self.interface_id
+    /// Returns the interfaces this address was discovered on.
+    pub fn interface_ids(&self) -> &[InterfaceId] {
+        &self.interface_ids
+    }
+
+    /// Adds an interface identifier if not already present.
+    pub(crate) fn add_interface_id(&mut self, id: InterfaceId) {
+        if !self.interface_ids.contains(&id) {
+            self.interface_ids.push(id);
+        }
     }
 }
 
@@ -137,14 +170,6 @@ impl ScopedIp {
             ScopedIp::V6(v6) => v6.addr.is_loopback(),
         }
     }
-
-    /// Returns the interface identifier for this address.
-    pub const fn interface_id(&self) -> &InterfaceId {
-        match self {
-            ScopedIp::V4(v4) => &v4.interface_id,
-            ScopedIp::V6(v6) => &v6.scope_id,
-        }
-    }
 }
 
 impl From<IpAddr> for ScopedIp {
@@ -152,7 +177,7 @@ impl From<IpAddr> for ScopedIp {
         match ip {
             IpAddr::V4(v4) => ScopedIp::V4(ScopedIpV4 {
                 addr: v4,
-                interface_id: InterfaceId::default(),
+                interface_ids: vec![],
             }),
             IpAddr::V6(v6) => ScopedIp::V6(ScopedIpV6 {
                 addr: v6,
@@ -167,7 +192,7 @@ impl From<&Interface> for ScopedIp {
         match interface.ip() {
             IpAddr::V4(v4) => ScopedIp::V4(ScopedIpV4 {
                 addr: v4,
-                interface_id: InterfaceId::from(interface),
+                interface_ids: vec![InterfaceId::from(interface)],
             }),
             IpAddr::V6(v6) => ScopedIp::V6(ScopedIpV6 {
                 addr: v6,
@@ -706,7 +731,7 @@ impl DnsAddress {
         match self.address {
             IpAddr::V4(v4) => ScopedIp::V4(ScopedIpV4 {
                 addr: v4,
-                interface_id: self.interface_id.clone(),
+                interface_ids: vec![self.interface_id.clone()],
             }),
             IpAddr::V6(v6) => ScopedIp::V6(ScopedIpV6 {
                 addr: v6,

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -2559,7 +2559,22 @@ impl Zeroconf {
                             dns_a.address().to_ip_addr()
                         );
                     } else {
-                        resolved_service.addresses.insert(dns_a.address());
+                        let scoped = dns_a.address();
+                        if let ScopedIp::V4(v4) = &scoped {
+                            // Merge interface_ids if this V4 addr already exists
+                            if let Some(mut existing) = resolved_service.addresses.take(&scoped) {
+                                if let ScopedIp::V4(existing_v4) = &mut existing {
+                                    for id in v4.interface_ids() {
+                                        existing_v4.add_interface_id(id.clone());
+                                    }
+                                }
+                                resolved_service.addresses.insert(existing);
+                            } else {
+                                resolved_service.addresses.insert(scoped);
+                            }
+                        } else {
+                            resolved_service.addresses.insert(scoped);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Problem

`ScopedIpV4` previously had a single `interface_id` (added in #439). This meant the same IPv4 address discovered via different interfaces would appear as two distinct entries in ResolvedService.addresses. This can cause confusion about how many IPv4 addresses actually discovered.

Unlike IPv6 link-local addresses where the scope ID is part of the address identity, for IPv4 the interface is discovery metadata.

### Changes

- `ScopedIpV4` to hold `Vec<InterfaceId>` instead of a single `interface_id`.
- Implements `Eq/Hash` manually based on `addr` only, so the same IPv4 address deduplicates correctly in HashSet<ScopedIp>.

