### PR TITLE
refactoring: simplify handle_query

### DIFF
--- a/src/dns_cache.rs
+++ b/src/dns_cache.rs
@@ -5,6 +5,7 @@
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::{
+    current_time_millis,
     dns_parser::{DnsAddress, DnsPointer, DnsRecordBox, DnsSrv, InterfaceId, RRType},
     service_info::{split_sub_domain, MyIntf},
     ScopedIp,
@@ -12,7 +13,6 @@ use crate::{
 use std::{
     collections::{HashMap, HashSet},
     ops::BitOr,
-    time::SystemTime,
 };
 
 /// Bitflags-style type for filtering by IP version.
@@ -947,12 +947,4 @@ mod tests {
             .collect();
         assert_eq!(all_ips, HashSet::from([addr_b]));
     }
-}
-
-/// Returns UNIX time in millis
-pub(crate) fn current_time_millis() -> u64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .expect("failed to get current UNIX time")
-        .as_millis() as u64
 }

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -1864,15 +1864,8 @@ impl DnsOutgoing {
         }
 
         // check if we changed our name due to conflicts.
-        let service_fullname = match dns_registry.name_changes.get(service.get_fullname()) {
-            Some(new_name) => new_name,
-            None => service.get_fullname(),
-        };
-
-        let hostname = match dns_registry.name_changes.get(service.get_hostname()) {
-            Some(new_name) => new_name,
-            None => service.get_hostname(),
-        };
+        let service_fullname = dns_registry.resolve_name(service.get_fullname());
+        let hostname = dns_registry.resolve_name(service.get_hostname());
 
         let ptr_added = self.add_answer(
             msg,

--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -7,6 +7,7 @@
 #[cfg(feature = "logging")]
 use crate::log::trace;
 
+use crate::current_time_millis;
 use crate::error::{e_fmt, Error, Result};
 use crate::service_info::{is_unicast_link_local, DnsRegistry, MyIntf, ServiceInfo};
 
@@ -24,7 +25,6 @@ use std::{
     hash::Hash,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     str,
-    time::SystemTime,
 };
 
 /// Represents a network interface identifier defined by the OS.
@@ -2591,14 +2591,6 @@ impl DnsIncoming {
 
         Ok(name)
     }
-}
-
-/// Returns UNIX time in millis
-fn current_time_millis() -> u64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .expect("failed to get current UNIX time")
-        .as_millis() as u64
 }
 
 const fn u16_from_be_slice(bytes: &[u8]) -> u16 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,3 +189,13 @@ pub use service_info::{
 
 /// A handler to receive messages from [ServiceDaemon]. Re-export from `flume` crate.
 pub use flume::Receiver;
+
+use std::time::SystemTime;
+
+/// Returns the current time in milliseconds since the UNIX epoch.
+pub(crate) fn current_time_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("failed to get current UNIX time")
+        .as_millis() as u64
+}

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -2118,15 +2118,9 @@ impl Zeroconf {
                         self.retransmissions.push(ReRun { next_time, command });
                         self.timers.push(Reverse(next_time));
 
-                        let fullname = match dns_registry.name_changes.get(&service_name) {
-                            Some(new_name) => new_name.to_string(),
-                            None => service_name.to_string(),
-                        };
+                        let fullname = dns_registry.resolve_name(&service_name).to_string();
 
-                        let mut hostname = info.get_hostname();
-                        if let Some(new_name) = dns_registry.name_changes.get(hostname) {
-                            hostname = new_name;
-                        }
+                        let hostname = dns_registry.resolve_name(info.get_hostname());
 
                         debug!("wake up: announce service {} on {}", fullname, intf.name);
                         notify_monitors(
@@ -3086,11 +3080,7 @@ impl Zeroconf {
                             continue;
                         }
 
-                        let service_hostname =
-                            match dns_registry.name_changes.get(service.get_hostname()) {
-                                Some(new_name) => new_name,
-                                None => service.get_hostname(),
-                            };
+                        let service_hostname = dns_registry.resolve_name(service.get_hostname());
 
                         if service_hostname.to_lowercase() == question.entry_name().to_lowercase() {
                             let intf_addrs = if is_ipv4 {
@@ -3134,13 +3124,7 @@ impl Zeroconf {
                 let service_opt = self
                     .my_services
                     .iter()
-                    .find(|(k, _v)| {
-                        let service_name = match dns_registry.name_changes.get(k.as_str()) {
-                            Some(new_name) => new_name,
-                            None => k,
-                        };
-                        service_name == &query_name
-                    })
+                    .find(|(k, _v)| dns_registry.resolve_name(k.as_str()) == query_name)
                     .map(|(_, v)| v);
 
                 let Some(service) = service_opt else {
@@ -3671,14 +3655,8 @@ impl Zeroconf {
         };
 
         if announced_v4 || announced_v6 {
-            let mut hostname = info.get_hostname();
-            if let Some(new_name) = dns_registry.name_changes.get(hostname) {
-                hostname = new_name;
-            }
-            let service_name = match dns_registry.name_changes.get(&fullname) {
-                Some(new_name) => new_name.to_string(),
-                None => fullname,
-            };
+            let hostname = dns_registry.resolve_name(info.get_hostname());
+            let service_name = dns_registry.resolve_name(&fullname).to_string();
 
             debug!("resend: announce service {service_name} on {}", intf.name);
 
@@ -4339,10 +4317,7 @@ fn prepare_announce(
     }
 
     // check if we changed our name due to conflicts.
-    let service_fullname = match dns_registry.name_changes.get(info.get_fullname()) {
-        Some(new_name) => new_name,
-        None => info.get_fullname(),
-    };
+    let service_fullname = dns_registry.resolve_name(info.get_fullname());
 
     debug!(
         "prepare to announce service {service_fullname} on {:?}",
@@ -4379,10 +4354,7 @@ fn prepare_announce(
     }
 
     // SRV records.
-    let hostname = match dns_registry.name_changes.get(info.get_hostname()) {
-        Some(new_name) => new_name.to_string(),
-        None => info.get_hostname().to_string(),
-    };
+    let hostname = dns_registry.resolve_name(info.get_hostname()).to_string();
 
     let mut srv = DnsSrv::new(
         info.get_fullname(),

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -3120,7 +3120,7 @@ impl Zeroconf {
                     }
                 }
 
-                let query_name = question.entry_name().to_lowercase();
+                let query_name = q_name.to_lowercase();
                 let service_opt = self
                     .my_services
                     .iter()

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -31,7 +31,8 @@
 #[cfg(feature = "logging")]
 use crate::log::{debug, error, trace};
 use crate::{
-    dns_cache::{current_time_millis, DnsCache, IpType},
+    current_time_millis,
+    dns_cache::{DnsCache, IpType},
     dns_parser::{
         ip_address_rr_type, DnsAddress, DnsEntryExt, DnsIncoming, DnsOutgoing, DnsPointer,
         DnsRecordBox, DnsRecordExt, DnsSrv, DnsTxt, InterfaceId, RRType, ScopedIp,
@@ -3075,14 +3076,7 @@ impl Zeroconf {
                 // Simultaneous Probe Tiebreaking (RFC 6762 section 8.2)
                 if qtype == RRType::ANY && msg.num_authorities() > 0 {
                     if let Some(probe) = dns_registry.probing.get_mut(q_name) {
-                        let now = current_time_millis();
-
-                        // Only do tiebreaking if probe already started.
-                        // This check also helps avoid redo tiebreaking if start time
-                        // was postponed.
-                        if probe.start_time < now {
-                            probe.tiebreaking(&msg, now, q_name);
-                        }
+                        probe.tiebreaking(&msg, q_name);
                     }
                 }
 

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -3052,6 +3052,7 @@ impl Zeroconf {
 
         for question in msg.questions().iter() {
             let qtype = question.entry_type();
+            let q_name = question.entry_name();
 
             if qtype == RRType::PTR {
                 for service in self.my_services.values() {
@@ -3059,25 +3060,13 @@ impl Zeroconf {
                         continue;
                     }
 
-                    if question.entry_name() == service.get_type()
-                        || service
-                            .get_subtype()
-                            .as_ref()
-                            .is_some_and(|v| v == question.entry_name())
-                    {
+                    if service.matches_type_or_subtype(q_name) {
                         out.add_answer_with_additionals(&msg, service, intf, dns_registry, is_ipv4);
-                    } else if question.entry_name() == META_QUERY {
-                        let ptr_added = out.add_answer(
-                            &msg,
-                            DnsPointer::new(
-                                question.entry_name(),
-                                RRType::PTR,
-                                CLASS_IN,
-                                service.get_other_ttl(),
-                                service.get_type().to_string(),
-                            ),
-                        );
-                        if !ptr_added {
+                    } else if q_name == META_QUERY {
+                        let ttl = service.get_other_ttl();
+                        let alias = service.get_type().to_string();
+                        let ptr = DnsPointer::new(q_name, RRType::PTR, CLASS_IN, ttl, alias);
+                        if !out.add_answer(&msg, ptr) {
                             trace!("answer was not added for meta-query {:?}", &question);
                         }
                     }
@@ -3085,22 +3074,14 @@ impl Zeroconf {
             } else {
                 // Simultaneous Probe Tiebreaking (RFC 6762 section 8.2)
                 if qtype == RRType::ANY && msg.num_authorities() > 0 {
-                    let probe_name = question.entry_name();
-
-                    if let Some(probe) = dns_registry.probing.get_mut(probe_name) {
+                    if let Some(probe) = dns_registry.probing.get_mut(q_name) {
                         let now = current_time_millis();
 
                         // Only do tiebreaking if probe already started.
                         // This check also helps avoid redo tiebreaking if start time
                         // was postponed.
                         if probe.start_time < now {
-                            let incoming_records: Vec<_> = msg
-                                .authorities()
-                                .iter()
-                                .filter(|r| r.get_name() == probe_name)
-                                .collect();
-
-                            probe.tiebreaking(&incoming_records, now, probe_name);
+                            probe.tiebreaking(&msg, now, q_name);
                         }
                     }
                 }

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -1052,7 +1052,16 @@ impl Probe {
     }
 
     /// Compares with `incoming` records. Postpone probe and retry if we yield.
-    pub(crate) fn tiebreaking(&mut self, msg: &DnsIncoming, now: u64, probe_name: &str) {
+    pub(crate) fn tiebreaking(&mut self, msg: &DnsIncoming, probe_name: &str) {
+        let now = crate::current_time_millis();
+
+        // Only do tiebreaking if probe already started.
+        // This check also helps avoid redo tiebreaking if start time
+        // was postponed.
+        if self.start_time >= now {
+            return;
+        }
+
         let incoming: Vec<_> = msg
             .authorities()
             .iter()

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -1154,6 +1154,14 @@ impl DnsRegistry {
         }
     }
 
+    /// Returns the renamed name if a name change exists, otherwise returns the original name.
+    pub(crate) fn resolve_name<'a>(&'a self, name: &'a str) -> &'a str {
+        match self.name_changes.get(name) {
+            Some(new_name) => new_name,
+            None => name,
+        }
+    }
+
     pub(crate) fn is_probing_done<T>(
         &mut self,
         answer: &T,

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::{
-    dns_parser::{DnsRecordBox, DnsRecordExt, DnsSrv, RRType, ScopedIp},
+    dns_parser::{DnsIncoming, DnsRecordBox, DnsRecordExt, DnsSrv, RRType, ScopedIp},
     Error, IfKind, InterfaceId, Result,
 };
 use if_addrs::{IfAddr, Interface};
@@ -283,6 +283,11 @@ impl ServiceInfo {
     #[inline]
     pub const fn get_subtype(&self) -> &Option<String> {
         &self.sub_domain
+    }
+
+    /// Returns whether the service type or subtype matches the given name.
+    pub(crate) fn matches_type_or_subtype(&self, name: &str) -> bool {
+        name == self.get_type() || self.get_subtype().as_ref().is_some_and(|v| v == name)
     }
 
     /// Returns a reference of the service fullname.
@@ -1047,7 +1052,12 @@ impl Probe {
     }
 
     /// Compares with `incoming` records. Postpone probe and retry if we yield.
-    pub(crate) fn tiebreaking(&mut self, incoming: &[&DnsRecordBox], now: u64, probe_name: &str) {
+    pub(crate) fn tiebreaking(&mut self, msg: &DnsIncoming, now: u64, probe_name: &str) {
+        let incoming: Vec<_> = msg
+            .authorities()
+            .iter()
+            .filter(|r| r.get_name() == probe_name)
+            .collect();
         /*
         RFC 6762 section 8.2: https://datatracker.ietf.org/doc/html/rfc6762#section-8.2
         ...


### PR DESCRIPTION
`handle_query` is a very long function. This is to simplify its code. No business logic changes.