### PR TITLE
chore(deps): update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,20 +18,19 @@ serde = ["dep:serde"]
 default = ["async", "logging"]
 
 [dependencies]
-fastrand = "2.3"
-flume = { version = "0.11", default-features = false } # channel between threads
+fastrand = "2.4"
+flume = { version = "0.12", default-features = false } # channel between threads
 if-addrs = { version = "0.15", features = ["link-local"] } # get local IP addresses
 log = { version = "0.4", optional = true }             # logging
-mio = { version = "1.1", features = ["os-poll", "net"] }  # select/poll sockets
+mio = { version = "1.2", features = ["os-poll", "net"] }  # select/poll sockets
 socket2 = { version = "0.6", features = ["all"] }      # socket APIs
-socket-pktinfo = "0.3.2"
+socket-pktinfo = "0.4.0"
 # support for serde's deserialize/serialize traits
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 
 [dev-dependencies]
 env_logger = { version = "= 0.10.2", default-features = false, features= ["humantime"] }
-fastrand = "2.3"
-humantime = "2.1"
+humantime = "2.3"
 serde_json = "1.0.149"
 test-log = "= 0.2.14"
 test-log-macros = "= 0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ socket-pktinfo = "0.4.0"
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 
 [dev-dependencies]
-env_logger = { version = "= 0.10.2", default-features = false, features= ["humantime"] }
-humantime = "2.3"
+env_logger = { version = "0.11.10", default-features = false, features = ["humantime"] }
+jiff = "0.2.23"
 serde_json = "1.0.149"
 test-log = "0.2.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,4 @@ serde = { version = "1.0.228", features = ["derive"], optional = true }
 env_logger = { version = "= 0.10.2", default-features = false, features= ["humantime"] }
 humantime = "2.3"
 serde_json = "1.0.149"
-test-log = "= 0.2.14"
-test-log-macros = "= 0.2.14"
+test-log = "0.2.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ socket-pktinfo = "0.4.0"
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 
 [dev-dependencies]
-env_logger = { version = "0.11.10", default-features = false, features = ["humantime"] }
-jiff = "0.2.28"
+env_logger = { version = "= 0.11.6", default-features = false, features = ["humantime"] }
+humantime = "2.3.0"
 serde_json = "1.0.150"
 test-log = "0.2.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,19 +18,19 @@ serde = ["dep:serde"]
 default = ["async", "logging"]
 
 [dependencies]
-fastrand = "2.3"
-flume = { version = "0.11", default-features = false } # channel between threads
+fastrand = "2.4"
+flume = { version = "0.12", default-features = false } # channel between threads
 if-addrs = { version = "0.15", features = ["link-local"] } # get local IP addresses
 log = { version = "0.4", optional = true }             # logging
-mio = { version = "1.1", features = ["os-poll", "net"] }  # select/poll sockets
+mio = { version = "1.2", features = ["os-poll", "net"] }  # select/poll sockets
 socket2 = { version = "0.6", features = ["all"] }      # socket APIs
-socket-pktinfo = "0.3.2"
+socket-pktinfo = "0.4.0"
 # support for serde's deserialize/serialize traits
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 
 [dev-dependencies]
 env_logger = { version = "= 0.10.2", default-features = false, features= ["humantime"] }
-humantime = "2.1"
+humantime = "2.3"
 serde_json = "1.0.149"
 test-log = "= 0.2.14"
 test-log-macros = "= 0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,6 @@ serde = { version = "1.0.228", features = ["derive"], optional = true }
 
 [dev-dependencies]
 env_logger = { version = "= 0.11.6", default-features = false, features = ["humantime"] }
-humantime = "2.3.0"
+humantime = "2.3"
 serde_json = "1.0.150"
 test-log = "0.2.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,6 @@ serde = { version = "1.0.228", features = ["derive"], optional = true }
 
 [dev-dependencies]
 env_logger = { version = "0.11.10", default-features = false, features = ["humantime"] }
-jiff = "0.2.23"
-serde_json = "1.0.149"
-test-log = "0.2.19"
+jiff = "0.2.28"
+serde_json = "1.0.150"
+test-log = "0.2.21"

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1515,6 +1515,7 @@ fn test_cache_flush_record() {
     .unwrap();
     let result = server.register(my_service);
     assert!(result.is_ok());
+    assert!(false);
 
     timed_println(format!(
         "Re-registered with updated IPv4 addr: {}",
@@ -2575,7 +2576,6 @@ fn test_interface_id_get_addrs() {
 
 /// A helper function to include a timestamp for println.
 fn timed_println(msg: String) {
-    let now = SystemTime::now();
-    let formatted_time = humantime::format_rfc3339(now);
+    let formatted_time = jiff::Timestamp::now().to_string();
     println!("[{}] {}", formatted_time, msg);
 }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1515,7 +1515,6 @@ fn test_cache_flush_record() {
     .unwrap();
     let result = server.register(my_service);
     assert!(result.is_ok());
-    assert!(false);
 
     timed_println(format!(
         "Re-registered with updated IPv4 addr: {}",

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1512,7 +1512,6 @@ fn test_cache_flush_record() {
     .unwrap();
     let result = server.register(my_service);
     assert!(result.is_ok());
-    assert!(false);
 
     timed_println(format!(
         "Re-registered with updated IPv4 addr: {}",

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -2572,6 +2572,7 @@ fn test_interface_id_get_addrs() {
 
 /// A helper function to include a timestamp for println.
 fn timed_println(msg: String) {
-    let formatted_time = jiff::Timestamp::now().to_string();
+    let now = SystemTime::now();
+    let formatted_time = humantime::format_rfc3339(now);
     println!("[{}] {}", formatted_time, msg);
 }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1512,6 +1512,7 @@ fn test_cache_flush_record() {
     .unwrap();
     let result = server.register(my_service);
     assert!(result.is_ok());
+    assert!(false);
 
     timed_println(format!(
         "Re-registered with updated IPv4 addr: {}",
@@ -2572,7 +2573,6 @@ fn test_interface_id_get_addrs() {
 
 /// A helper function to include a timestamp for println.
 fn timed_println(msg: String) {
-    let now = SystemTime::now();
-    let formatted_time = humantime::format_rfc3339(now);
+    let formatted_time = jiff::Timestamp::now().to_string();
     println!("[{}] {}", formatted_time, msg);
 }


### PR DESCRIPTION
Also removes `test-log-macros` as we are on `1.71` [now](https://github.com/keepsimple1/mdns-sd/pull/324#issuecomment-2708655869).
Not sure why we had `fastrand` defined again in dev-deps (as its already in deps), #455 removes its usage in tests.