### PR TITLE
Fix ScopedIp serialization with MessagePack

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -124,7 +124,6 @@ impl ScopedIpV6 {
 /// An IP address, either IPv4 or IPv6, that supports scope_id for IPv6.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "serde", serde(untagged))]
 #[non_exhaustive]
 pub enum ScopedIp {
     V4(ScopedIpV4),


### PR DESCRIPTION
The `serde(untagged)` attribute on Enums breaks serialization with binary formats like MessagePack.

I originally added that tag to optimize the redundant structures when serializing, but this can also be achieved when using `serde(flatten)` on a per-implementation basis.

Through my own testing using `rmp-serde`, I can confirm that it works after this change. If requested, I can write an additional test to cover this case.

EDIT: Actually not a problem with the format, seems like it's [an issue with rmp-serde](https://github.com/3Hren/msgpack-rust/issues/354).