### PR TITLE
feat: Implement RFC 6762 section 6 multicast rate limiting

### DIFF
--- a/src/dns_parser.rs
+++ b/src/dns_parser.rs
@@ -1786,6 +1786,22 @@ impl DnsOutgoing {
         self.authorities.push(record);
     }
 
+    /// Retains only the answers for which `keep` returns true.
+    pub(crate) fn retain_answers<F>(&mut self, mut keep: F)
+    where
+        F: FnMut(&DnsRecordBox) -> bool,
+    {
+        self.answers.retain(|(record, _)| keep(record));
+    }
+
+    /// Retains only the additional records for which `keep` returns true.
+    pub(crate) fn retain_additionals<F>(&mut self, mut keep: F)
+    where
+        F: FnMut(&DnsRecordBox) -> bool,
+    {
+        self.additionals.retain(|record| keep(record));
+    }
+
     /// Returns true if `answer` is added to the outgoing msg.
     /// Returns false if `answer` was not added as it expired or suppressed by the incoming `msg`.
     pub fn add_answer(

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -3333,7 +3333,7 @@ impl Zeroconf {
                 //   - Answering probe queries: a probe carries the proposed
                 //     records in its Authority Section, and we MUST defend our
                 //     records immediately so the prober detects the conflict.
-                dns_registry.apply_multicast_rate_limit(&mut out, current_time_millis());
+                dns_registry.apply_multicast_rate_limit(&mut out, current_time_millis(), is_ipv4);
             }
 
             if out.answers_count() > 0 {
@@ -4671,7 +4671,7 @@ fn announce_service_on_intf(
     if let Some(mut out) = prepare_announce(info, intf, dns_registry, is_ipv4) {
         // RFC 6762 §6: a record MUST NOT be multicast on an interface more than
         // once per second. Announcements are unsolicited multicast responses.
-        dns_registry.apply_multicast_rate_limit(&mut out, current_time_millis());
+        dns_registry.apply_multicast_rate_limit(&mut out, current_time_millis(), is_ipv4);
         if out.answers_count() > 0 {
             let _ = send_dns_outgoing(&out, intf, sock, port, None, None)?;
         }

--- a/src/service_daemon.rs
+++ b/src/service_daemon.rs
@@ -3299,7 +3299,6 @@ impl Zeroconf {
         }
 
         if out.answers_count() > 0 {
-            debug!("sending response on intf {}", &intf.name);
             out.set_id(msg.id());
 
             // Pick a source IfAddr on `intf` whose subnet contains the querier's IP.
@@ -3327,24 +3326,35 @@ impl Zeroconf {
                     out.add_question(q.entry_name(), q.entry_type());
                 }
                 out.clear_cache_flush_bits();
+            } else if msg.num_authorities() == 0 {
+                // RFC 6762 §6: a record MUST NOT be multicast on an interface
+                // more than once per second. Two exceptions skip the limit here:
+                //   - Unicast responses (handled above).
+                //   - Answering probe queries: a probe carries the proposed
+                //     records in its Authority Section, and we MUST defend our
+                //     records immediately so the prober detects the conflict.
+                dns_registry.apply_multicast_rate_limit(&mut out, current_time_millis());
             }
 
-            if let Err(InternalError::IntfAddrInvalid(intf_addr)) = send_dns_outgoing(
-                &out,
-                intf,
-                &sock.pktinfo,
-                self.port,
-                matched_source,
-                unicast_dest,
-            ) {
-                let invalid_intf_addr = HashSet::from([intf_addr]);
-                let _ = self.send_cmd_to_self(Command::InvalidIntfAddrs(invalid_intf_addr));
+            if out.answers_count() > 0 {
+                debug!("sending response on intf {}", &intf.name);
+                if let Err(InternalError::IntfAddrInvalid(intf_addr)) = send_dns_outgoing(
+                    &out,
+                    intf,
+                    &sock.pktinfo,
+                    self.port,
+                    matched_source,
+                    unicast_dest,
+                ) {
+                    let invalid_intf_addr = HashSet::from([intf_addr]);
+                    let _ = self.send_cmd_to_self(Command::InvalidIntfAddrs(invalid_intf_addr));
+                }
+
+                let if_name = intf.name.clone();
+
+                self.increase_counter(Counter::Respond, 1);
+                self.notify_monitors(DaemonEvent::Respond(if_name));
             }
-
-            let if_name = intf.name.clone();
-
-            self.increase_counter(Counter::Respond, 1);
-            self.notify_monitors(DaemonEvent::Respond(if_name));
         }
 
         self.increase_counter(Counter::KnownAnswerSuppression, out.known_answer_count());
@@ -4658,8 +4668,13 @@ fn announce_service_on_intf(
     port: u16,
 ) -> MyResult<bool> {
     let is_ipv4 = sock.domain() == Domain::IPV4;
-    if let Some(out) = prepare_announce(info, intf, dns_registry, is_ipv4) {
-        let _ = send_dns_outgoing(&out, intf, sock, port, None, None)?;
+    if let Some(mut out) = prepare_announce(info, intf, dns_registry, is_ipv4) {
+        // RFC 6762 §6: a record MUST NOT be multicast on an interface more than
+        // once per second. Announcements are unsolicited multicast responses.
+        dns_registry.apply_multicast_rate_limit(&mut out, current_time_millis());
+        if out.answers_count() > 0 {
+            let _ = send_dns_outgoing(&out, intf, sock, port, None, None)?;
+        }
         return Ok(true);
     }
 

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -1143,9 +1143,18 @@ pub(crate) struct DnsRegistry {
     pub(crate) name_changes: HashMap<String, String>,
 
     /// RFC 6762 section 6: the last time (in millis) each record was multicast
-    /// on this interface, keyed by the record's identity (name + type + rdata).
-    /// Used to enforce the per-record, per-interface one-second rate limit.
-    pub(crate) last_multicast: HashMap<String, u64>,
+    /// on this interface's IPv4 group, keyed by the record's identity
+    /// (name + type + rdata). Used to enforce the per-record, per-interface
+    /// one-second rate limit.
+    ///
+    /// IPv4 and IPv6 are tracked separately: a single interface (`if_index`)
+    /// carries both address families, but they are distinct multicast groups
+    /// (`224.0.0.251` and `ff02::fb`) reaching potentially different listeners,
+    /// so sending a record on one group must not throttle it on the other.
+    pub(crate) last_multicast_v4: HashMap<String, u64>,
+
+    /// Same as [`Self::last_multicast_v4`] but for this interface's IPv6 group.
+    pub(crate) last_multicast_v6: HashMap<String, u64>,
 }
 
 impl DnsRegistry {
@@ -1155,7 +1164,8 @@ impl DnsRegistry {
             active: HashMap::new(),
             new_timers: Vec::new(),
             name_changes: HashMap::new(),
-            last_multicast: HashMap::new(),
+            last_multicast_v4: HashMap::new(),
+            last_multicast_v6: HashMap::new(),
         }
     }
 
@@ -1165,18 +1175,30 @@ impl DnsRegistry {
     /// least one second has elapsed since the last time that record was
     /// multicast on that particular interface.
     ///
+    /// `is_ipv4` selects the per-family bucket: the IPv4 and IPv6 groups on one
+    /// interface are throttled independently (see [`Self::last_multicast_v4`]).
+    ///
     /// Drops from `out` any answer or additional record that was multicast within the
     /// last second, and records `now` as the last-multicast time for the records kept.
     ///
     /// This must NOT be applied to probe queries, legacy unicast responses, or
     /// goodbye packets, which are exempt from the rate limit.
-    pub(crate) fn apply_multicast_rate_limit(&mut self, out: &mut DnsOutgoing, now: u64) {
+    pub(crate) fn apply_multicast_rate_limit(
+        &mut self,
+        out: &mut DnsOutgoing,
+        now: u64,
+        is_ipv4: bool,
+    ) {
+        let last_multicast = if is_ipv4 {
+            &mut self.last_multicast_v4
+        } else {
+            &mut self.last_multicast_v6
+        };
+
         // Prune stale entries so the map stays bounded across name changes;
         // any record older than the one-second window is irrelevant now.
-        self.last_multicast
-            .retain(|_, last| now.saturating_sub(*last) < 1000);
+        last_multicast.retain(|_, last| now.saturating_sub(*last) < 1000);
 
-        let last_multicast = &mut self.last_multicast;
         out.retain_answers(|record| keep_after_rate_limit(last_multicast, record, now));
 
         // Only touch additionals if an answer survived.
@@ -1498,18 +1520,67 @@ mod tests {
 
         // First multicast at `now`: the record passes through.
         let mut out = build_out();
-        registry.apply_multicast_rate_limit(&mut out, now);
+        registry.apply_multicast_rate_limit(&mut out, now, true);
         assert_eq!(out.answers_count(), 1);
 
         // Again 500ms later: the record is throttled (dropped).
         let mut out = build_out();
-        registry.apply_multicast_rate_limit(&mut out, now + 500);
+        registry.apply_multicast_rate_limit(&mut out, now + 500, true);
         assert_eq!(out.answers_count(), 0);
 
         // Exactly 1 second after the first send: allowed again.
         let mut out = build_out();
-        registry.apply_multicast_rate_limit(&mut out, now + 1000);
+        registry.apply_multicast_rate_limit(&mut out, now + 1000, true);
         assert_eq!(out.answers_count(), 1);
+    }
+
+    /// A single interface carries both IPv4 and IPv6, but they are distinct
+    /// multicast groups reaching different listeners, so the one-second limit
+    /// is tracked per family: multicasting a record on IPv4 must NOT throttle
+    /// the same record on IPv6 (and vice versa). Otherwise the shared PTR/SRV/
+    /// TXT records would be stripped from whichever family is sent second.
+    #[test]
+    fn test_multicast_rate_limit_per_family() {
+        let mut registry = DnsRegistry::new();
+
+        let build_out = || {
+            let mut out = DnsOutgoing::new(FLAGS_QR_RESPONSE);
+            out.add_answer_at_time(
+                DnsPointer::new(
+                    "_test._tcp.local.",
+                    RRType::PTR,
+                    CLASS_IN,
+                    4500,
+                    "inst._test._tcp.local.".to_string(),
+                ),
+                0,
+            );
+            out
+        };
+
+        let now = 1_000_000;
+
+        // Multicast the record on IPv4: passes through.
+        let mut out = build_out();
+        registry.apply_multicast_rate_limit(&mut out, now, true);
+        assert_eq!(out.answers_count(), 1);
+
+        // The same record on IPv6 immediately after: must still pass, because
+        // the IPv6 group has its own bucket.
+        let mut out = build_out();
+        registry.apply_multicast_rate_limit(&mut out, now, false);
+        assert_eq!(out.answers_count(), 1);
+
+        // A second IPv4 send within the window is still throttled, confirming
+        // the IPv6 send did not reset (or get charged to) the IPv4 bucket.
+        let mut out = build_out();
+        registry.apply_multicast_rate_limit(&mut out, now + 500, true);
+        assert_eq!(out.answers_count(), 0);
+
+        // Likewise a second IPv6 send within the window is throttled.
+        let mut out = build_out();
+        registry.apply_multicast_rate_limit(&mut out, now + 500, false);
+        assert_eq!(out.answers_count(), 0);
     }
 
     /// When every answer is throttled the packet is not sent, so any surviving
@@ -1544,7 +1615,7 @@ mod tests {
         // Send the PTR answer once so it is throttled going forward.
         let mut out = DnsOutgoing::new(FLAGS_QR_RESPONSE);
         out.add_answer_at_time(ptr_answer(), 0);
-        registry.apply_multicast_rate_limit(&mut out, now);
+        registry.apply_multicast_rate_limit(&mut out, now, true);
         assert_eq!(out.answers_count(), 1);
 
         // 100ms later: PTR answer is throttled, and `extra` rides along as an
@@ -1552,7 +1623,7 @@ mod tests {
         let mut out = DnsOutgoing::new(FLAGS_QR_RESPONSE);
         out.add_answer_at_time(ptr_answer(), 0);
         out.add_additional_answer(extra());
-        registry.apply_multicast_rate_limit(&mut out, now + 100);
+        registry.apply_multicast_rate_limit(&mut out, now + 100, true);
         assert_eq!(out.answers_count(), 0);
 
         // 200ms later: `extra` is now requested as a real answer. It must pass,
@@ -1560,7 +1631,7 @@ mod tests {
         // unsent additional), so the 1-second limit does not apply to it.
         let mut out = DnsOutgoing::new(FLAGS_QR_RESPONSE);
         out.add_answer_at_time(extra(), 0);
-        registry.apply_multicast_rate_limit(&mut out, now + 200);
+        registry.apply_multicast_rate_limit(&mut out, now + 200, true);
         assert_eq!(out.answers_count(), 1);
     }
 

--- a/src/service_info.rs
+++ b/src/service_info.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::{
-    dns_parser::{DnsIncoming, DnsRecordBox, DnsRecordExt, DnsSrv, RRType, ScopedIp},
+    dns_parser::{DnsIncoming, DnsOutgoing, DnsRecordBox, DnsRecordExt, DnsSrv, RRType, ScopedIp},
     Error, IfKind, InterfaceId, Result,
 };
 use if_addrs::{IfAddr, Interface};
@@ -1141,6 +1141,11 @@ pub(crate) struct DnsRegistry {
 
     /// Mapping from original names to new names.
     pub(crate) name_changes: HashMap<String, String>,
+
+    /// RFC 6762 section 6: the last time (in millis) each record was multicast
+    /// on this interface, keyed by the record's identity (name + type + rdata).
+    /// Used to enforce the per-record, per-interface one-second rate limit.
+    pub(crate) last_multicast: HashMap<String, u64>,
 }
 
 impl DnsRegistry {
@@ -1150,6 +1155,33 @@ impl DnsRegistry {
             active: HashMap::new(),
             new_timers: Vec::new(),
             name_changes: HashMap::new(),
+            last_multicast: HashMap::new(),
+        }
+    }
+
+    /// Enforces the RFC 6762 section 6 multicast rate limit on `out`.
+    ///
+    /// A responder MUST NOT multicast a record on a given interface until at
+    /// least one second has elapsed since the last time that record was
+    /// multicast on that particular interface.
+    ///
+    /// Drops from `out` any answer or additional record that was multicast within the
+    /// last second, and records `now` as the last-multicast time for the records kept.
+    ///
+    /// This must NOT be applied to probe queries, legacy unicast responses, or
+    /// goodbye packets, which are exempt from the rate limit.
+    pub(crate) fn apply_multicast_rate_limit(&mut self, out: &mut DnsOutgoing, now: u64) {
+        // Prune stale entries so the map stays bounded across name changes;
+        // any record older than the one-second window is irrelevant now.
+        self.last_multicast
+            .retain(|_, last| now.saturating_sub(*last) < 1000);
+
+        let last_multicast = &mut self.last_multicast;
+        out.retain_answers(|record| keep_after_rate_limit(last_multicast, record, now));
+
+        // Only touch additionals if an answer survived.
+        if out.answers_count() > 0 {
+            out.retain_additionals(|record| keep_after_rate_limit(last_multicast, record, now));
         }
     }
 
@@ -1288,6 +1320,36 @@ impl DnsRegistry {
     }
 }
 
+/// Returns whether `record` may still be multicast under the RFC 6762 section 6
+/// rate limit, updating `last_multicast` to `now` when it is kept.
+fn keep_after_rate_limit(
+    last_multicast: &mut HashMap<String, u64>,
+    record: &DnsRecordBox,
+    now: u64,
+) -> bool {
+    let key = rate_limit_key(record);
+    match last_multicast.get(&key) {
+        Some(last) if now.saturating_sub(*last) < 1000 => false,
+        _ => {
+            last_multicast.insert(key, now);
+            true
+        }
+    }
+}
+
+/// Builds the identity key for a record used by the RFC 6762 section 6
+/// multicast rate limit: name (case-insensitive) + type + rdata. TTL and the
+/// cache-flush bit are intentionally excluded, so the same logical record maps
+/// to a single key regardless of the TTL it is sent with.
+fn rate_limit_key(record: &DnsRecordBox) -> String {
+    format!(
+        "{}-{}-{}",
+        record.get_name().to_lowercase(),
+        record.get_type(),
+        record.rdata_print(),
+    )
+}
+
 /// Returns a tuple of (service_type_domain, optional_sub_domain)
 pub(crate) fn split_sub_domain(domain: &str) -> (&str, Option<&str>) {
     if let Some((_, ty_domain)) = domain.rsplit_once("._sub.") {
@@ -1404,10 +1466,103 @@ impl ResolvedService {
 
 #[cfg(test)]
 mod tests {
-    use super::{decode_txt, encode_txt, u8_slice_to_hex, ServiceInfo, TxtProperty};
+    use super::{decode_txt, encode_txt, u8_slice_to_hex, DnsRegistry, ServiceInfo, TxtProperty};
+    use crate::dns_parser::{DnsOutgoing, DnsPointer, RRType, CLASS_IN, FLAGS_QR_RESPONSE};
     use crate::{IfKind, IfPredicate};
     use if_addrs::{IfAddr, IfOperStatus, Ifv4Addr, Ifv6Addr, Interface};
     use std::net::{Ipv4Addr, Ipv6Addr};
+
+    /// RFC 6762 section 6: the same record must not be multicast on an
+    /// interface more than once per second, but is allowed again after a
+    /// second has elapsed.
+    #[test]
+    fn test_multicast_rate_limit() {
+        let mut registry = DnsRegistry::new();
+
+        let build_out = || {
+            let mut out = DnsOutgoing::new(FLAGS_QR_RESPONSE);
+            out.add_answer_at_time(
+                DnsPointer::new(
+                    "_test._tcp.local.",
+                    RRType::PTR,
+                    CLASS_IN,
+                    4500,
+                    "inst._test._tcp.local.".to_string(),
+                ),
+                0,
+            );
+            out
+        };
+
+        let now = 1_000_000;
+
+        // First multicast at `now`: the record passes through.
+        let mut out = build_out();
+        registry.apply_multicast_rate_limit(&mut out, now);
+        assert_eq!(out.answers_count(), 1);
+
+        // Again 500ms later: the record is throttled (dropped).
+        let mut out = build_out();
+        registry.apply_multicast_rate_limit(&mut out, now + 500);
+        assert_eq!(out.answers_count(), 0);
+
+        // Exactly 1 second after the first send: allowed again.
+        let mut out = build_out();
+        registry.apply_multicast_rate_limit(&mut out, now + 1000);
+        assert_eq!(out.answers_count(), 1);
+    }
+
+    /// When every answer is throttled the packet is not sent, so any surviving
+    /// additional record must NOT be stamped as multicast — otherwise a later
+    /// answer for that same record would be wrongly throttled even though it was
+    /// never put on the wire.
+    #[test]
+    fn test_multicast_rate_limit_additionals_not_stamped_without_answer() {
+        let mut registry = DnsRegistry::new();
+
+        let ptr_answer = || {
+            DnsPointer::new(
+                "_test._tcp.local.",
+                RRType::PTR,
+                CLASS_IN,
+                4500,
+                "inst._test._tcp.local.".to_string(),
+            )
+        };
+        let extra = || {
+            DnsPointer::new(
+                "_other._tcp.local.",
+                RRType::PTR,
+                CLASS_IN,
+                4500,
+                "inst._other._tcp.local.".to_string(),
+            )
+        };
+
+        let now = 1_000_000;
+
+        // Send the PTR answer once so it is throttled going forward.
+        let mut out = DnsOutgoing::new(FLAGS_QR_RESPONSE);
+        out.add_answer_at_time(ptr_answer(), 0);
+        registry.apply_multicast_rate_limit(&mut out, now);
+        assert_eq!(out.answers_count(), 1);
+
+        // 100ms later: PTR answer is throttled, and `extra` rides along as an
+        // additional. With no answer surviving, nothing is sent.
+        let mut out = DnsOutgoing::new(FLAGS_QR_RESPONSE);
+        out.add_answer_at_time(ptr_answer(), 0);
+        out.add_additional_answer(extra());
+        registry.apply_multicast_rate_limit(&mut out, now + 100);
+        assert_eq!(out.answers_count(), 0);
+
+        // 200ms later: `extra` is now requested as a real answer. It must pass,
+        // because it was never actually multicast above (only carried as an
+        // unsent additional), so the 1-second limit does not apply to it.
+        let mut out = DnsOutgoing::new(FLAGS_QR_RESPONSE);
+        out.add_answer_at_time(extra(), 0);
+        registry.apply_multicast_rate_limit(&mut out, now + 200);
+        assert_eq!(out.answers_count(), 1);
+    }
 
     #[test]
     fn test_txt_encode_decode() {


### PR DESCRIPTION
RFC 6762 section 6 requires:

"To protect the network against excessive packet flooding due to software bugs or malicious attack, a Multicast DNS responder MUST NOT (except in the one special case of answering probe queries) multicast a record on a given interface until at least one second has elapsed since the last time that record was multicast on that particular interface."

We weren't enforcing this, so rapid queries or repeated announcements could re-multicast the same record with no throttling. This PR adds per-record, per-interface rate limiting.

### Throttled (multicast responses):

- Query responses — handle_query, multicast branch only
- Announcements / unsolicited responses — announce_service_on_intf

### Exempt, per the RFC 

- Probe queries — it should have an interval of at least 250ms instead (not implemented yet)
- Legacy unicast responses (§6.7) — the limit is specifically about multicast