### PR TITLE
feat: re-export Receiver error types (#488)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,7 @@ pub use service_info::{
 /// A handler to receive messages from [ServiceDaemon]. Re-export from `flume` crate.
 pub use flume::Receiver;
 
-/// Errors returned by the receiving methods of [Receiver]. Re-export from `flume` crate.
+/// Errors returned by the receiving methods of `Receiver`. Re-export from `flume` crate.
 pub use flume::{RecvError, RecvTimeoutError, TryRecvError};
 
 use std::time::SystemTime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,8 +188,9 @@ pub use service_info::{
     AsIpAddrs, IntoTxtProperties, ResolvedService, ServiceInfo, TxtProperties, TxtProperty,
 };
 
-/// A handler to receive messages from [ServiceDaemon]. Re-export from `flume` crate.
-pub use flume::Receiver;
+/// A handler to receive messages from [ServiceDaemon], and the errors its receiving
+/// methods return. Re-export from `flume` crate.
+pub use flume::{Receiver, RecvError, RecvTimeoutError, TryRecvError};
 
 use std::time::SystemTime;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,9 +188,11 @@ pub use service_info::{
     AsIpAddrs, IntoTxtProperties, ResolvedService, ServiceInfo, TxtProperties, TxtProperty,
 };
 
-/// A handler to receive messages from [ServiceDaemon], and the errors its receiving
-/// methods return. Re-export from `flume` crate.
-pub use flume::{Receiver, RecvError, RecvTimeoutError, TryRecvError};
+/// A handler to receive messages from [ServiceDaemon]. Re-export from `flume` crate.
+pub use flume::Receiver;
+
+/// Errors returned by the receiving methods of [Receiver]. Re-export from `flume` crate.
+pub use flume::{RecvError, RecvTimeoutError, TryRecvError};
 
 use std::time::SystemTime;
 


### PR DESCRIPTION
Fixes #488 

## Problem:
`Receiver` was re-exported but its error types were not, so a caller that wanted to name `RecvError` -- to write `impl From<RecvError>` for its own error type, for example -- had to add `flume` as a direct dependency.

## Fix: 
Re-export the three receiver-side error types. 